### PR TITLE
Fix typos in infill rotation tooltips (#9986)

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3119,7 +3119,7 @@ void PrintConfigDef::init_fff_params()
     def->tooltip  = L("This parameter adds a rotation of sparse infill direction to each layer according to the specified template. "
                       "The template is a comma-separated list of angles in degrees, e.g. '0,90'. "
                       "The first angle is applied to the first layer, the second angle to the second layer, and so on. "
-                      "If there are more layers than angles, the angles will be repeated. Note that not all all sparse infill patterns support rotation.");
+                      "If there are more layers than angles, the angles will be repeated. Note that not all sparse infill patterns support rotation.");
     def->sidetext = L("°");
     def->mode     = comAdvanced;
     def->set_default_value(new ConfigOptionString("0,90"));
@@ -3131,7 +3131,7 @@ void PrintConfigDef::init_fff_params()
     def->tooltip  = L("This parameter adds a rotation of solid infill direction to each layer according to the specified template. "
                       "The template is a comma-separated list of angles in degrees, e.g. '0,90'. "
                       "The first angle is applied to the first layer, the second angle to the second layer, and so on. "
-                      "If there are more layers than angles, the angles will be repeated. Note that not all all solid infill patterns support rotation.");
+                      "If there are more layers than angles, the angles will be repeated. Note that not all solid infill patterns support rotation.");
     def->sidetext = L("°");
     def->mode     = comAdvanced;
     def->set_default_value(new ConfigOptionString("0,90"));


### PR DESCRIPTION
Corrected duplicated word 'all' in the tooltips for sparse and solid infill rotation parameters.