### PR TITLE
Fix Staggered Perimeters warning on EVERY config change 

### DIFF
--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -342,7 +342,7 @@ void ConfigManipulation::update_print_fff_config(DynamicPrintConfig* config, con
 	if (!is_plate_config &&
         config->opt_bool("staggered_perimeters") &&
         (abs(config->opt_float("initial_layer_print_height") - config->opt_float("layer_height")) > EPSILON  ||
-        !(config->option<ConfigOptionFloatOrPercent>("top_surface_line_width") == config->option<ConfigOptionFloatOrPercent>("outer_wall_line_width")) ||
+        !(*config->option<ConfigOptionFloatOrPercent>("top_surface_line_width") == *config->option<ConfigOptionFloatOrPercent>("outer_wall_line_width")) ||
             !have_arachne ||
             config->opt_bool("spiral_mode")))
     {


### PR DESCRIPTION
Staggered perimeters warnings(the popup saying staggered perimeters is an experimental feature and only works when ...) were triggered on every config change because the guard compared `ConfigOptionFloatOrPercent*` instances rather than their values. Dereferencing both pointers before the equality check resolves it so that the warning only shows if there is a conflicting setting active.