### PR TITLE
Fix precise wall warning

### DIFF
--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1755,8 +1755,8 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
             // }
 
             // check wall sequence and precise outer wall
-            if (m_default_region_config.precise_outer_wall && 
-                    (m_default_region_config.wall_sequence == WallSequence::InnerOuter ||
+            if (m_default_region_config.precise_outer_wall &&
+                    (m_default_region_config.wall_sequence == WallSequence::OuterInner ||
                      m_default_region_config.wall_sequence == WallSequence::InnerOuterInner ||
                      (m_default_region_config.wall_sequence == WallSequence::OddEven && !m_default_region_config.outermost_wall_control))) {
                 warning->string  = L("The precise wall option will be ignored for outer-inner, inner-outer-inner or odd-even (without outermost control) wall sequences. ");


### PR DESCRIPTION
The check to display the warning incorrectly flags inner outter and not outter inner for precise wall. The warning message itself is correct and matches the actual logic for ignoring precise wall on certain wall orders:
https://github.com/NanashiTheNameless/OrcaSlicer/blob/f8b54843bfcd4f6549bc4f51b2c28e14359ac211/src/libslic3r/PerimeterGenerator.cpp#L1211-L1216