### PR TITLE
Add Coex 3D filament profiles to Orcaslicer (#10924)

### DIFF
--- a/resources/profiles/BBL.json
+++ b/resources/profiles/BBL.json
@@ -6,16 +6,12 @@
     "description": "the initial version of BBL configurations",
     "machine_model_list": [
         {
-            "name": "Bambu Lab X1 Carbon",
-            "sub_path": "machine/Bambu Lab X1 Carbon.json"
+            "name": "Bambu Lab A1",
+            "sub_path": "machine/Bambu Lab A1.json"
         },
         {
-            "name": "Bambu Lab X1",
-            "sub_path": "machine/Bambu Lab X1.json"
-        },
-        {
-            "name": "Bambu Lab X1E",
-            "sub_path": "machine/Bambu Lab X1E.json"
+            "name": "Bambu Lab A1 mini",
+            "sub_path": "machine/Bambu Lab A1 mini.json"
         },
         {
             "name": "Bambu Lab P1P",
@@ -26,12 +22,16 @@
             "sub_path": "machine/Bambu Lab P1S.json"
         },
         {
-            "name": "Bambu Lab A1 mini",
-            "sub_path": "machine/Bambu Lab A1 mini.json"
+            "name": "Bambu Lab X1",
+            "sub_path": "machine/Bambu Lab X1.json"
         },
         {
-            "name": "Bambu Lab A1",
-            "sub_path": "machine/Bambu Lab A1.json"
+            "name": "Bambu Lab X1 Carbon",
+            "sub_path": "machine/Bambu Lab X1 Carbon.json"
+        },
+        {
+            "name": "Bambu Lab X1E",
+            "sub_path": "machine/Bambu Lab X1E.json"
         }
     ],
     "process_list": [
@@ -606,8 +606,80 @@
     ],
     "filament_list": [
         {
+            "name": "COEX PCTG PRIME @BBL X1C",
+            "sub_path": "filament/COEX/COEX PCTG PRIME @BBL X1C.json"
+        },
+        {
+            "name": "COEX PCTG PRIME @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX PCTG PRIME @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX PCTG PRIME @BBL X1C 0.8 nozzle",
+            "sub_path": "filament/COEX/COEX PCTG PRIME @BBL X1C 0.8 nozzle.json"
+        },
+        {
+            "name": "COEX PETG @BBL X1C",
+            "sub_path": "filament/COEX/COEX PETG @BBL X1C.json"
+        },
+        {
+            "name": "COEX PETG @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX PETG @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX PETG @BBL X1C 0.8 nozzle",
+            "sub_path": "filament/COEX/COEX PETG @BBL X1C 0.8 nozzle.json"
+        },
+        {
+            "name": "COEX PLA @BBL A1M",
+            "sub_path": "filament/COEX/COEX PLA @BBL A1M.json"
+        },
+        {
+            "name": "COEX PLA @BBL P1P",
+            "sub_path": "filament/COEX/COEX PLA @BBL P1P.json"
+        },
+        {
+            "name": "COEX PLA @BBL X1C",
+            "sub_path": "filament/COEX/COEX PLA @BBL X1C.json"
+        },
+        {
             "name": "fdm_filament_common",
             "sub_path": "filament/fdm_filament_common.json"
+        },
+        {
+            "name": "COEX PCTG PRIME @BBL A1M 0.4 nozzle",
+            "sub_path": "filament/COEX/COEX PCTG PRIME @BBL A1M.json"
+        },
+        {
+            "name": "COEX PCTG PRIME @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX PCTG PRIME @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX PCTG PRIME @BBL A1M 0.8 nozzle",
+            "sub_path": "filament/COEX/COEX PCTG PRIME @BBL A1M 0.8 nozzle.json"
+        },
+        {
+            "name": "COEX PETG @BBL A1M 0.4 nozzle",
+            "sub_path": "filament/COEX/COEX PETG @BBL A1M.json"
+        },
+        {
+            "name": "COEX PETG @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX PETG @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX PETG @BBL A1M 0.8 nozzle",
+            "sub_path": "filament/COEX/COEX PETG @BBL A1M 0.8 nozzle.json"
+        },
+        {
+            "name": "COEX PLA @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX PLA @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX PLA @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX PLA @BBL P1P 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX PLA @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX PLA @BBL X1C 0.2 nozzle.json"
         },
         {
             "name": "FusRock ABS-GF @base",
@@ -4186,6 +4258,282 @@
             "sub_path": "filament/AliZ/AliZ PLA @P1-X1.json"
         },
         {
+            "name": "COEX ABS @BBL X1",
+            "sub_path": "filament/COEX/COEX ABS @BBL X1.json"
+        },
+        {
+            "name": "COEX ABS @BBL X1 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX ABS @BBL X1 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX ABS @BBL X1C",
+            "sub_path": "filament/COEX/COEX ABS @BBL X1C.json"
+        },
+        {
+            "name": "COEX ABS @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX ABS @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX ABS PRIME @BBL X1",
+            "sub_path": "filament/COEX/COEX ABS PRIME @BBL X1.json"
+        },
+        {
+            "name": "COEX ABS PRIME @BBL X1 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX ABS PRIME @BBL X1 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX ABS PRIME @BBL X1C",
+            "sub_path": "filament/COEX/COEX ABS PRIME @BBL X1C.json"
+        },
+        {
+            "name": "COEX ABS PRIME @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX ABS PRIME @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX ASA PRIME @BBL X1",
+            "sub_path": "filament/COEX/COEX ASA PRIME @BBL X1.json"
+        },
+        {
+            "name": "COEX ASA PRIME @BBL X1 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX ASA PRIME @BBL X1 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX ASA PRIME @BBL X1C",
+            "sub_path": "filament/COEX/COEX ASA PRIME @BBL X1C.json"
+        },
+        {
+            "name": "COEX ASA PRIME @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX ASA PRIME @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX NYLEX PA6-CF @BBL X1C",
+            "sub_path": "filament/COEX/COEX NYLEX PA6-CF @BBL X1C.json"
+        },
+        {
+            "name": "COEX NYLEX UNFILLED  @BBL X1C",
+            "sub_path": "filament/COEX/COEX NYLEX UNFILLED @BBL X1C.json"
+        },
+        {
+            "name": "COEX PCTG PRIME @BBL A1",
+            "sub_path": "filament/COEX/COEX PCTG PRIME @BBL A1.json"
+        },
+        {
+            "name": "COEX PCTG PRIME @BBL A1 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX PCTG PRIME @BBL A1 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX PCTG PRIME @BBL A1 0.8 nozzle",
+            "sub_path": "filament/COEX/COEX PCTG PRIME @BBL A1 0.8 nozzle.json"
+        },
+        {
+            "name": "COEX PETG @BBL A1",
+            "sub_path": "filament/COEX/COEX PETG @BBL A1.json"
+        },
+        {
+            "name": "COEX PETG @BBL A1 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX PETG @BBL A1 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX PETG @BBL A1 0.8 nozzle",
+            "sub_path": "filament/COEX/COEX PETG @BBL A1 0.8 nozzle.json"
+        },
+        {
+            "name": "COEX PLA @BBL A1",
+            "sub_path": "filament/COEX/COEX PLA @BBL A1.json"
+        },
+        {
+            "name": "COEX PLA @BBL A1 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX PLA @BBL A1 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX PLA @BBL X1",
+            "sub_path": "filament/COEX/COEX PLA @BBL X1.json"
+        },
+        {
+            "name": "COEX PLA PRIME @BBL A1",
+            "sub_path": "filament/COEX/COEX PLA PRIME @BBL A1.json"
+        },
+        {
+            "name": "COEX PLA PRIME @BBL A1 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX PLA PRIME @BBL A1 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX PLA PRIME @BBL A1M",
+            "sub_path": "filament/COEX/COEX PLA PRIME @BBL A1M.json"
+        },
+        {
+            "name": "COEX PLA PRIME @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX PLA PRIME @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX PLA PRIME @BBL P1P",
+            "sub_path": "filament/COEX/COEX PLA PRIME @BBL P1P.json"
+        },
+        {
+            "name": "COEX PLA PRIME @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX PLA PRIME @BBL P1P 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX PLA PRIME @BBL X1",
+            "sub_path": "filament/COEX/COEX PLA PRIME @BBL X1.json"
+        },
+        {
+            "name": "COEX PLA PRIME @BBL X1 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX PLA PRIME @BBL X1 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX PLA PRIME @BBL X1C",
+            "sub_path": "filament/COEX/COEX PLA PRIME @BBL X1C.json"
+        },
+        {
+            "name": "COEX PLA PRIME @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX PLA PRIME @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX PLA+Silk @BBL A1",
+            "sub_path": "filament/COEX/COEX PLA+Silk @BBL A1.json"
+        },
+        {
+            "name": "COEX PLA+Silk @BBL A1 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX PLA+Silk @BBL A1 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX PLA+Silk @BBL A1M",
+            "sub_path": "filament/COEX/COEX PLA+Silk @BBL A1M.json"
+        },
+        {
+            "name": "COEX PLA+Silk @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX PLA+Silk @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX PLA+Silk @BBL P1P",
+            "sub_path": "filament/COEX/COEX PLA+Silk @BBL P1P.json"
+        },
+        {
+            "name": "COEX PLA+Silk @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX PLA+Silk @BBL P1P 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX PLA+Silk @BBL X1",
+            "sub_path": "filament/COEX/COEX PLA+Silk @BBL X1.json"
+        },
+        {
+            "name": "COEX PLA+Silk @BBL X1 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX PLA+Silk @BBL X1 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX PLA+Silk @BBL X1C",
+            "sub_path": "filament/COEX/COEX PLA+Silk @BBL X1C.json"
+        },
+        {
+            "name": "COEX PLA+Silk @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX PLA+Silk @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX TPE 30D @BBL A1",
+            "sub_path": "filament/COEX/COEX TPE 30D @BBL A1.json"
+        },
+        {
+            "name": "COEX TPE 30D @BBL A1M",
+            "sub_path": "filament/COEX/COEX TPE 30D @BBL A1M.json"
+        },
+        {
+            "name": "COEX TPE 30D @BBL P1P",
+            "sub_path": "filament/COEX/COEX TPE 30D @BBL P1P.json"
+        },
+        {
+            "name": "COEX TPE 30D @BBL X1",
+            "sub_path": "filament/COEX/COEX TPE 30D @BBL X1.json"
+        },
+        {
+            "name": "COEX TPE 30D @BBL X1C",
+            "sub_path": "filament/COEX/COEX TPE 30D @BBL X1C.json"
+        },
+        {
+            "name": "COEX TPE 40D @BBL A1",
+            "sub_path": "filament/COEX/COEX TPE 40D @BBL A1.json"
+        },
+        {
+            "name": "COEX TPE 40D @BBL A1 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX TPE 40D @BBL A1 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX TPE 40D @BBL A1M",
+            "sub_path": "filament/COEX/COEX TPE 40D @BBL A1M.json"
+        },
+        {
+            "name": "COEX TPE 40D @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX TPE 40D @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX TPE 40D @BBL P1P",
+            "sub_path": "filament/COEX/COEX TPE 40D @BBL P1P.json"
+        },
+        {
+            "name": "COEX TPE 40D @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX TPE 40D @BBL P1P 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX TPE 40D @BBL X1",
+            "sub_path": "filament/COEX/COEX TPE 40D @BBL X1.json"
+        },
+        {
+            "name": "COEX TPE 40D @BBL X1 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX TPE 40D @BBL X1 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX TPE 40D @BBL X1C",
+            "sub_path": "filament/COEX/COEX TPE 40D @BBL X1C.json"
+        },
+        {
+            "name": "COEX TPE 40D @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX TPE 40D @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX TPE 60D @BBL A1",
+            "sub_path": "filament/COEX/COEX TPE 60D @BBL A1.json"
+        },
+        {
+            "name": "COEX TPE 60D @BBL A1 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX TPE 60D @BBL A1 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX TPE 60D @BBL A1M",
+            "sub_path": "filament/COEX/COEX TPE 60D @BBL A1M.json"
+        },
+        {
+            "name": "COEX TPE 60D @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX TPE 60D @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX TPE 60D @BBL P1P",
+            "sub_path": "filament/COEX/COEX TPE 60D @BBL P1P.json"
+        },
+        {
+            "name": "COEX TPE 60D @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX TPE 60D @BBL P1P 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX TPE 60D @BBL X1",
+            "sub_path": "filament/COEX/COEX TPE 60D @BBL X1.json"
+        },
+        {
+            "name": "COEX TPE 60D @BBL X1 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX TPE 60D @BBL X1 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX TPE 60D @BBL X1C",
+            "sub_path": "filament/COEX/COEX TPE 60D @BBL X1C.json"
+        },
+        {
+            "name": "COEX TPE 60D @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/COEX/COEX TPE 60D @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "COEX TPU 60A @BBL X1C",
+            "sub_path": "filament/COEX/COEX TPU 60A @BBL X1C.json"
+        },
+        {
             "name": "Overture ASA @BBL X1",
             "sub_path": "filament/Overture/Overture ASA @BBL X1.json"
         },
@@ -4452,12 +4800,12 @@
             "sub_path": "machine/fdm_bbl_3dp_001_common.json"
         },
         {
-            "name": "Bambu Lab X1 Carbon 0.4 nozzle",
-            "sub_path": "machine/Bambu Lab X1 Carbon 0.4 nozzle.json"
+            "name": "Bambu Lab A1 0.4 nozzle",
+            "sub_path": "machine/Bambu Lab A1 0.4 nozzle.json"
         },
         {
-            "name": "Bambu Lab X1 0.4 nozzle",
-            "sub_path": "machine/Bambu Lab X1 0.4 nozzle.json"
+            "name": "Bambu Lab A1 mini 0.4 nozzle",
+            "sub_path": "machine/Bambu Lab A1 mini 0.4 nozzle.json"
         },
         {
             "name": "Bambu Lab P1P 0.4 nozzle",
@@ -4468,40 +4816,40 @@
             "sub_path": "machine/Bambu Lab P1S 0.4 nozzle.json"
         },
         {
-            "name": "Bambu Lab A1 mini 0.4 nozzle",
-            "sub_path": "machine/Bambu Lab A1 mini 0.4 nozzle.json"
+            "name": "Bambu Lab X1 0.4 nozzle",
+            "sub_path": "machine/Bambu Lab X1 0.4 nozzle.json"
+        },
+        {
+            "name": "Bambu Lab X1 Carbon 0.4 nozzle",
+            "sub_path": "machine/Bambu Lab X1 Carbon 0.4 nozzle.json"
         },
         {
             "name": "Bambu Lab X1E 0.4 nozzle",
             "sub_path": "machine/Bambu Lab X1E 0.4 nozzle.json"
         },
         {
-            "name": "Bambu Lab A1 0.4 nozzle",
-            "sub_path": "machine/Bambu Lab A1 0.4 nozzle.json"
+            "name": "Bambu Lab A1 0.2 nozzle",
+            "sub_path": "machine/Bambu Lab A1 0.2 nozzle.json"
         },
         {
-            "name": "Bambu Lab X1 Carbon 0.2 nozzle",
-            "sub_path": "machine/Bambu Lab X1 Carbon 0.2 nozzle.json"
+            "name": "Bambu Lab A1 0.6 nozzle",
+            "sub_path": "machine/Bambu Lab A1 0.6 nozzle.json"
         },
         {
-            "name": "Bambu Lab X1 Carbon 0.6 nozzle",
-            "sub_path": "machine/Bambu Lab X1 Carbon 0.6 nozzle.json"
+            "name": "Bambu Lab A1 0.8 nozzle",
+            "sub_path": "machine/Bambu Lab A1 0.8 nozzle.json"
         },
         {
-            "name": "Bambu Lab X1 Carbon 0.8 nozzle",
-            "sub_path": "machine/Bambu Lab X1 Carbon 0.8 nozzle.json"
+            "name": "Bambu Lab A1 mini 0.2 nozzle",
+            "sub_path": "machine/Bambu Lab A1 mini 0.2 nozzle.json"
         },
         {
-            "name": "Bambu Lab X1 0.2 nozzle",
-            "sub_path": "machine/Bambu Lab X1 0.2 nozzle.json"
+            "name": "Bambu Lab A1 mini 0.6 nozzle",
+            "sub_path": "machine/Bambu Lab A1 mini 0.6 nozzle.json"
         },
         {
-            "name": "Bambu Lab X1 0.8 nozzle",
-            "sub_path": "machine/Bambu Lab X1 0.8 nozzle.json"
-        },
-        {
-            "name": "Bambu Lab X1 0.6 nozzle",
-            "sub_path": "machine/Bambu Lab X1 0.6 nozzle.json"
+            "name": "Bambu Lab A1 mini 0.8 nozzle",
+            "sub_path": "machine/Bambu Lab A1 mini 0.8 nozzle.json"
         },
         {
             "name": "Bambu Lab P1P 0.2 nozzle",
@@ -4528,16 +4876,28 @@
             "sub_path": "machine/Bambu Lab P1S 0.8 nozzle.json"
         },
         {
-            "name": "Bambu Lab A1 mini 0.2 nozzle",
-            "sub_path": "machine/Bambu Lab A1 mini 0.2 nozzle.json"
+            "name": "Bambu Lab X1 0.2 nozzle",
+            "sub_path": "machine/Bambu Lab X1 0.2 nozzle.json"
         },
         {
-            "name": "Bambu Lab A1 mini 0.6 nozzle",
-            "sub_path": "machine/Bambu Lab A1 mini 0.6 nozzle.json"
+            "name": "Bambu Lab X1 0.6 nozzle",
+            "sub_path": "machine/Bambu Lab X1 0.6 nozzle.json"
         },
         {
-            "name": "Bambu Lab A1 mini 0.8 nozzle",
-            "sub_path": "machine/Bambu Lab A1 mini 0.8 nozzle.json"
+            "name": "Bambu Lab X1 0.8 nozzle",
+            "sub_path": "machine/Bambu Lab X1 0.8 nozzle.json"
+        },
+        {
+            "name": "Bambu Lab X1 Carbon 0.2 nozzle",
+            "sub_path": "machine/Bambu Lab X1 Carbon 0.2 nozzle.json"
+        },
+        {
+            "name": "Bambu Lab X1 Carbon 0.6 nozzle",
+            "sub_path": "machine/Bambu Lab X1 Carbon 0.6 nozzle.json"
+        },
+        {
+            "name": "Bambu Lab X1 Carbon 0.8 nozzle",
+            "sub_path": "machine/Bambu Lab X1 Carbon 0.8 nozzle.json"
         },
         {
             "name": "Bambu Lab X1E 0.2 nozzle",
@@ -4550,18 +4910,6 @@
         {
             "name": "Bambu Lab X1E 0.8 nozzle",
             "sub_path": "machine/Bambu Lab X1E 0.8 nozzle.json"
-        },
-        {
-            "name": "Bambu Lab A1 0.2 nozzle",
-            "sub_path": "machine/Bambu Lab A1 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu Lab A1 0.6 nozzle",
-            "sub_path": "machine/Bambu Lab A1 0.6 nozzle.json"
-        },
-        {
-            "name": "Bambu Lab A1 0.8 nozzle",
-            "sub_path": "machine/Bambu Lab A1 0.8 nozzle.json"
         }
     ]
 }

--- a/resources/profiles/BBL/filament/COEX/COEX ABS @BBL X1 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX ABS @BBL X1 0.2 nozzle.json
@@ -1,0 +1,23 @@
+{
+  "type": "filament",
+  "name": "COEX ABS @BBL X1 0.2 nozzle",
+  "inherits": "COEX ABS @base",
+  "from": "system",
+  "setting_id": "CXABSB01_02",
+  "instantiation": "true",
+  "compatible_printers": [
+    "Bambu Lab X1 0.2 nozzle"
+  ],
+  "fan_max_speed": [
+    "100"
+  ],
+  "fan_min_speed": [
+    "100"
+  ],
+  "filament_flow_ratio": [
+    "0.98"
+  ],
+  "filament_max_volumetric_speed": [
+    "1.6"
+  ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX ABS @BBL X1.json
+++ b/resources/profiles/BBL/filament/COEX/COEX ABS @BBL X1.json
@@ -1,0 +1,25 @@
+{
+    "type": "filament",
+    "name": "COEX ABS @BBL X1",
+    "inherits": "COEX ABS @base",
+    "from": "system",
+    "setting_id": "CXABSB01_03",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 0.4 nozzle",
+        "Bambu Lab X1 0.6 nozzle",
+        "Bambu Lab X1 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX ABS @BBL X1C 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX ABS @BBL X1C 0.2 nozzle.json
@@ -1,0 +1,25 @@
+{
+  "type": "filament",
+  "name": "COEX ABS @BBL X1C 0.2 nozzle",
+  "inherits": "COEX ABS @base",
+  "from": "system",
+  "setting_id": "CXABSB01_04",
+  "instantiation": "true",
+  "compatible_printers": [
+    "Bambu Lab X1 Carbon 0.2 nozzle",
+    "Bambu Lab P1S 0.2 nozzle",
+    "Bambu Lab X1E 0.2 nozzle"
+  ],
+  "fan_max_speed": [
+    "100"
+  ],
+  "fan_min_speed": [
+    "100"
+  ],
+  "filament_flow_ratio": [
+    "0.98"
+  ],
+  "filament_max_volumetric_speed": [
+    "1.6"
+  ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX ABS @BBL X1C.json
+++ b/resources/profiles/BBL/filament/COEX/COEX ABS @BBL X1C.json
@@ -1,0 +1,31 @@
+{
+    "type": "filament",
+    "name": "COEX ABS @BBL X1C",
+    "inherits": "COEX ABS @base",
+    "from": "system",
+    "setting_id": "CXABSB01_01",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.4 nozzle",
+        "Bambu Lab X1 Carbon 0.6 nozzle",
+        "Bambu Lab X1 Carbon 0.8 nozzle",
+        "Bambu Lab P1S 0.4 nozzle",
+        "Bambu Lab P1S 0.6 nozzle",
+        "Bambu Lab P1S 0.8 nozzle",
+        "Bambu Lab X1E 0.4 nozzle",
+        "Bambu Lab X1E 0.6 nozzle",
+        "Bambu Lab X1E 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX ABS PRIME @BBL X1 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX ABS PRIME @BBL X1 0.2 nozzle.json
@@ -1,0 +1,23 @@
+{
+  "type": "filament",
+  "name": "COEX ABS PRIME @BBL X1 0.2 nozzle",
+  "inherits": "COEX ABS PRIME @base",
+  "from": "system",
+  "setting_id": "CXABPB09_02",
+  "instantiation": "true",
+  "compatible_printers": [
+    "Bambu Lab X1 0.2 nozzle"
+  ],
+  "fan_max_speed": [
+    "100"
+  ],
+  "fan_min_speed": [
+    "100"
+  ],
+  "filament_flow_ratio": [
+    "0.98"
+  ],
+  "filament_max_volumetric_speed": [
+    "1.6"
+  ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX ABS PRIME @BBL X1.json
+++ b/resources/profiles/BBL/filament/COEX/COEX ABS PRIME @BBL X1.json
@@ -1,0 +1,25 @@
+{
+    "type": "filament",
+    "name": "COEX ABS PRIME @BBL X1",
+    "inherits": "COEX ABS PRIME @base",
+    "from": "system",
+    "setting_id": "CXABPB09_03",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 0.4 nozzle",
+        "Bambu Lab X1 0.6 nozzle",
+        "Bambu Lab X1 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX ABS PRIME @BBL X1C 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX ABS PRIME @BBL X1C 0.2 nozzle.json
@@ -1,0 +1,25 @@
+{
+  "type": "filament",
+  "name": "COEX ABS PRIME @BBL X1C 0.2 nozzle",
+  "inherits": "COEX ABS PRIME @base",
+  "from": "system",
+  "setting_id": "CXABPB09_04",
+  "instantiation": "true",
+  "compatible_printers": [
+    "Bambu Lab X1 Carbon 0.2 nozzle",
+    "Bambu Lab P1S 0.2 nozzle",
+    "Bambu Lab X1E 0.2 nozzle"
+  ],
+  "fan_max_speed": [
+    "100"
+  ],
+  "fan_min_speed": [
+    "100"
+  ],
+  "filament_flow_ratio": [
+    "0.98"
+  ],
+  "filament_max_volumetric_speed": [
+    "1.6"
+  ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX ABS PRIME @BBL X1C.json
+++ b/resources/profiles/BBL/filament/COEX/COEX ABS PRIME @BBL X1C.json
@@ -1,0 +1,31 @@
+{
+    "type": "filament",
+    "name": "COEX ABS PRIME @BBL X1C",
+    "inherits": "COEX ABS PRIME @base",
+    "from": "system",
+    "setting_id": "CXABPB09_01",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.4 nozzle",
+        "Bambu Lab X1 Carbon 0.6 nozzle",
+        "Bambu Lab X1 Carbon 0.8 nozzle",
+        "Bambu Lab P1S 0.4 nozzle",
+        "Bambu Lab P1S 0.6 nozzle",
+        "Bambu Lab P1S 0.8 nozzle",
+        "Bambu Lab X1E 0.4 nozzle",
+        "Bambu Lab X1E 0.6 nozzle",
+        "Bambu Lab X1E 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX ASA PRIME @BBL X1 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX ASA PRIME @BBL X1 0.2 nozzle.json
@@ -1,0 +1,23 @@
+{
+  "type": "filament",
+  "name": "COEX ASA PRIME @BBL X1 0.2 nozzle",
+  "inherits": "COEX ASA PRIME @base",
+  "from": "system",
+  "setting_id": "CXASAB04_01",
+  "instantiation": "true",
+  "compatible_printers": [
+    "Bambu Lab X1 0.2 nozzle"
+  ],
+  "fan_max_speed": [
+    "100"
+  ],
+  "fan_min_speed": [
+    "100"
+  ],
+  "filament_flow_ratio": [
+    "0.98"
+  ],
+  "filament_max_volumetric_speed": [
+    "1.6"
+  ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX ASA PRIME @BBL X1.json
+++ b/resources/profiles/BBL/filament/COEX/COEX ASA PRIME @BBL X1.json
@@ -1,0 +1,25 @@
+{
+    "type": "filament",
+    "name": "COEX ASA PRIME @BBL X1",
+    "inherits": "COEX ASA PRIME @base",
+    "from": "system",
+    "setting_id": "CXASAB04_02",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 0.4 nozzle",
+        "Bambu Lab X1 0.6 nozzle",
+        "Bambu Lab X1 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX ASA PRIME @BBL X1C 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX ASA PRIME @BBL X1C 0.2 nozzle.json
@@ -1,0 +1,25 @@
+{
+  "type": "filament",
+  "name": "COEX ASA PRIME @BBL X1C 0.2 nozzle",
+  "inherits": "COEX ASA PRIME @base",
+  "from": "system",
+  "setting_id": "CXASAB04_03",
+  "instantiation": "true",
+  "compatible_printers": [
+    "Bambu Lab X1 Carbon 0.2 nozzle",
+    "Bambu Lab P1S 0.2 nozzle",
+    "Bambu Lab X1E 0.2 nozzle"
+  ],
+  "fan_max_speed": [
+    "100"
+  ],
+  "fan_min_speed": [
+    "100"
+  ],
+  "filament_flow_ratio": [
+    "0.98"
+  ],
+  "filament_max_volumetric_speed": [
+    "1.6"
+  ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX ASA PRIME @BBL X1C.json
+++ b/resources/profiles/BBL/filament/COEX/COEX ASA PRIME @BBL X1C.json
@@ -1,0 +1,31 @@
+{
+    "type": "filament",
+    "name": "COEX ASA PRIME @BBL X1C",
+    "inherits": "COEX ASA PRIME @base",
+    "from": "system",
+    "setting_id": "CXASAB04_04",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.4 nozzle",
+        "Bambu Lab X1 Carbon 0.6 nozzle",
+        "Bambu Lab X1 Carbon 0.8 nozzle",
+        "Bambu Lab P1S 0.4 nozzle",
+        "Bambu Lab P1S 0.6 nozzle",
+        "Bambu Lab P1S 0.8 nozzle",
+        "Bambu Lab X1E 0.4 nozzle",
+        "Bambu Lab X1E 0.6 nozzle",
+        "Bambu Lab X1E 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX NYLEX PA6-CF @BBL X1C.json
+++ b/resources/profiles/BBL/filament/COEX/COEX NYLEX PA6-CF @BBL X1C.json
@@ -1,0 +1,19 @@
+{
+    "type": "filament",
+    "name": "COEX NYLEX PA6-CF @BBL X1C",
+    "inherits": "COEX NYLEX PA6-CF @base",
+    "from": "system",
+    "setting_id": "CXPACB23_01",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab P1S 0.4 nozzle",
+        "Bambu Lab P1S 0.6 nozzle",
+        "Bambu Lab P1S 0.8 nozzle",
+        "Bambu Lab X1 Carbon 0.4 nozzle",
+        "Bambu Lab X1 Carbon 0.6 nozzle",
+        "Bambu Lab X1 Carbon 0.8 nozzle",
+		"Bambu Lab X1E 0.4 nozzle",
+        "Bambu Lab X1E 0.6 nozzle",
+        "Bambu Lab X1E 0.8 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX NYLEX UNFILLED @BBL X1C.json
+++ b/resources/profiles/BBL/filament/COEX/COEX NYLEX UNFILLED @BBL X1C.json
@@ -1,0 +1,31 @@
+{
+    "type": "filament",
+    "name": "COEX NYLEX UNFILLED  @BBL X1C",
+    "inherits": "COEX NYLEX UNFILLED @base",
+    "from": "system",
+    "setting_id": "CXPAUB21_01",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.4 nozzle",
+        "Bambu Lab X1 Carbon 0.6 nozzle",
+        "Bambu Lab X1 Carbon 0.8 nozzle",
+        "Bambu Lab P1S 0.4 nozzle",
+        "Bambu Lab P1S 0.6 nozzle",
+        "Bambu Lab P1S 0.8 nozzle",
+        "Bambu Lab X1E 0.4 nozzle",
+        "Bambu Lab X1E 0.6 nozzle",
+        "Bambu Lab X1E 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PCTG PRIME @BBL A1 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PCTG PRIME @BBL A1 0.2 nozzle.json
@@ -1,0 +1,17 @@
+{
+    "type": "filament",
+    "name": "COEX PCTG PRIME @BBL A1 0.2 nozzle",
+    "inherits": "COEX PCTG PRIME @base",
+    "from": "system",
+    "setting_id": "CXPCTX09",
+    "instantiation": "true",
+    "filament_flow_ratio": [
+        "0.94"
+    ],
+    "filament_max_volumetric_speed": [
+        "6"
+    ],
+    "compatible_printers": [
+        "Bambu Lab A1 0.2 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PCTG PRIME @BBL A1 0.8 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PCTG PRIME @BBL A1 0.8 nozzle.json
@@ -1,0 +1,24 @@
+{
+    "type": "filament",
+    "name": "COEX PCTG PRIME @BBL A1 0.8 nozzle",
+    "inherits": "COEX PCTG PRIME @base",
+    "from": "system",
+    "setting_id": "CXPCTX08",
+    "instantiation": "true",
+    "fan_max_speed": [
+        "60"
+    ],
+    "fan_min_speed": [
+        "20"
+    ],
+    "filament_flow_ratio": [
+        "0.94"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "compatible_printers": [
+        "Bambu Lab A1 0.8 nozzle",
+        "Bambu Lab A1 0.6 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PCTG PRIME @BBL A1.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PCTG PRIME @BBL A1.json
@@ -1,0 +1,17 @@
+{
+    "type": "filament",
+    "name": "COEX PCTG PRIME @BBL A1",
+    "inherits": "COEX PCTG PRIME @base",
+    "from": "system",
+    "setting_id": "CXPCTX07",
+    "instantiation": "true",
+    "filament_flow_ratio": [
+        "0.94"
+    ],
+    "filament_max_volumetric_speed": [
+        "9"
+    ],
+    "compatible_printers": [
+        "Bambu Lab A1 0.4 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PCTG PRIME @BBL A1M 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PCTG PRIME @BBL A1M 0.2 nozzle.json
@@ -1,0 +1,20 @@
+{
+    "type": "filament",
+    "name": "COEX PCTG PRIME @BBL A1M 0.2 nozzle",
+    "inherits": "COEX PCTG PRIME @BBL X1C 0.2 nozzle",
+    "from": "system",
+    "setting_id": "CXPCTX06",
+    "instantiation": "true",
+    "filament_flow_ratio": [
+        "0.94"
+    ],
+    "filament_long_retractions_when_cut": [
+        "nil"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil"
+    ],
+    "compatible_printers": [
+        "Bambu Lab A1 mini 0.2 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PCTG PRIME @BBL A1M 0.8 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PCTG PRIME @BBL A1M 0.8 nozzle.json
@@ -1,0 +1,24 @@
+{
+    "type": "filament",
+    "name": "COEX PCTG PRIME @BBL A1M 0.8 nozzle",
+    "inherits": "COEX PCTG PRIME @BBL X1C 0.8 nozzle",
+    "from": "system",
+    "setting_id": "CXPCTX05",
+    "instantiation": "true",
+    "filament_flow_ratio": [
+        "0.94"
+    ],
+    "filament_long_retractions_when_cut": [
+        "nil"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil"
+    ],
+    "compatible_printers": [
+        "Bambu Lab A1 mini 0.6 nozzle",
+        "Bambu Lab A1 mini 0.8 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PCTG PRIME @BBL A1M.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PCTG PRIME @BBL A1M.json
@@ -1,0 +1,23 @@
+{
+    "type": "filament",
+    "name": "COEX PCTG PRIME @BBL A1M 0.4 nozzle",
+    "inherits": "COEX PCTG PRIME @BBL X1C",
+    "from": "system",
+    "setting_id": "CXPCTX04",
+    "instantiation": "true",
+    "filament_flow_ratio": [
+        "0.94"
+    ],
+    "filament_long_retractions_when_cut": [
+        "nil"
+    ],
+    "filament_max_volumetric_speed": [
+        "9"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil"
+    ],
+    "compatible_printers": [
+        "Bambu Lab A1 mini 0.4 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PCTG PRIME @BBL X1C 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PCTG PRIME @BBL X1C 0.2 nozzle.json
@@ -1,0 +1,24 @@
+{
+    "type": "filament",
+    "name": "COEX PCTG PRIME @BBL X1C 0.2 nozzle",
+    "inherits": "COEX PCTG PRIME @base",
+    "from": "system",
+    "setting_id": "CXPCTX03",
+    "instantiation": "true",
+    "filament_max_volumetric_speed": [
+        "6"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "18"
+    ],
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.2 nozzle",
+        "Bambu Lab X1 0.2 nozzle",
+        "Bambu Lab P1P 0.2 nozzle",
+        "Bambu Lab P1S 0.2 nozzle",
+        "Bambu Lab X1E 0.2 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PCTG PRIME @BBL X1C 0.8 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PCTG PRIME @BBL X1C 0.8 nozzle.json
@@ -1,0 +1,35 @@
+{
+    "type": "filament",
+    "name": "COEX PCTG PRIME @BBL X1C 0.8 nozzle",
+    "inherits": "COEX PCTG PRIME @base",
+    "from": "system",
+    "setting_id": "CXPCTX02",
+    "instantiation": "true",
+    "fan_max_speed": [
+        "40"
+    ],
+    "fan_min_speed": [
+        "20"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "18"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ],
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.6 nozzle",
+        "Bambu Lab X1 0.6 nozzle",
+        "Bambu Lab P1P 0.6 nozzle",
+        "Bambu Lab X1 Carbon 0.8 nozzle",
+        "Bambu Lab X1 0.8 nozzle",
+        "Bambu Lab P1P 0.8 nozzle",
+        "Bambu Lab P1S 0.6 nozzle",
+        "Bambu Lab P1S 0.8 nozzle",
+        "Bambu Lab X1E 0.6 nozzle",
+        "Bambu Lab X1E 0.8 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PCTG PRIME @BBL X1C.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PCTG PRIME @BBL X1C.json
@@ -1,0 +1,24 @@
+{
+    "type": "filament",
+    "name": "COEX PCTG PRIME @BBL X1C",
+    "inherits": "COEX PCTG PRIME @base",
+    "from": "system",
+    "setting_id": "CXPCTX01",
+    "instantiation": "true",
+    "filament_max_volumetric_speed": [
+        "14"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "18"
+    ],
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.4 nozzle",
+        "Bambu Lab X1 0.4 nozzle",
+        "Bambu Lab P1P 0.4 nozzle",
+        "Bambu Lab P1S 0.4 nozzle",
+        "Bambu Lab X1E 0.4 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PETG @BBL A1 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PETG @BBL A1 0.2 nozzle.json
@@ -1,0 +1,17 @@
+{
+    "type": "filament",
+    "name": "COEX PETG @BBL A1 0.2 nozzle",
+    "inherits": "COEX PETG @base",
+    "from": "system",
+    "setting_id": "CXPETX09",
+    "instantiation": "true",
+    "filament_flow_ratio": [
+        "0.94"
+    ],
+    "filament_max_volumetric_speed": [
+        "6"
+    ],
+    "compatible_printers": [
+        "Bambu Lab A1 0.2 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PETG @BBL A1 0.8 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PETG @BBL A1 0.8 nozzle.json
@@ -1,0 +1,24 @@
+{
+    "type": "filament",
+    "name": "COEX PETG @BBL A1 0.8 nozzle",
+    "inherits": "COEX PETG @base",
+    "from": "system",
+    "setting_id": "CXPETX08",
+    "instantiation": "true",
+    "fan_max_speed": [
+        "60"
+    ],
+    "fan_min_speed": [
+        "20"
+    ],
+    "filament_flow_ratio": [
+        "0.94"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "compatible_printers": [
+        "Bambu Lab A1 0.8 nozzle",
+        "Bambu Lab A1 0.6 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PETG @BBL A1.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PETG @BBL A1.json
@@ -1,0 +1,17 @@
+{
+    "type": "filament",
+    "name": "COEX PETG @BBL A1",
+    "inherits": "COEX PETG @base",
+    "from": "system",
+    "setting_id": "CXPETX07",
+    "instantiation": "true",
+    "filament_flow_ratio": [
+        "0.94"
+    ],
+    "filament_max_volumetric_speed": [
+        "9"
+    ],
+    "compatible_printers": [
+        "Bambu Lab A1 0.4 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PETG @BBL A1M 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PETG @BBL A1M 0.2 nozzle.json
@@ -1,0 +1,20 @@
+{
+    "type": "filament",
+    "name": "COEX PETG @BBL A1M 0.2 nozzle",
+    "inherits": "COEX PETG @BBL X1C 0.2 nozzle",
+    "from": "system",
+    "setting_id": "CXPETX06",
+    "instantiation": "true",
+    "filament_flow_ratio": [
+        "0.94"
+    ],
+    "filament_long_retractions_when_cut": [
+        "nil"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil"
+    ],
+    "compatible_printers": [
+        "Bambu Lab A1 mini 0.2 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PETG @BBL A1M 0.8 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PETG @BBL A1M 0.8 nozzle.json
@@ -1,0 +1,24 @@
+{
+    "type": "filament",
+    "name": "COEX PETG @BBL A1M 0.8 nozzle",
+    "inherits": "COEX PETG @BBL X1C 0.8 nozzle",
+    "from": "system",
+    "setting_id": "CXPETX05",
+    "instantiation": "true",
+    "filament_flow_ratio": [
+        "0.94"
+    ],
+    "filament_long_retractions_when_cut": [
+        "nil"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil"
+    ],
+    "compatible_printers": [
+        "Bambu Lab A1 mini 0.6 nozzle",
+        "Bambu Lab A1 mini 0.8 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PETG @BBL A1M.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PETG @BBL A1M.json
@@ -1,0 +1,23 @@
+{
+    "type": "filament",
+    "name": "COEX PETG @BBL A1M 0.4 nozzle",
+    "inherits": "COEX PETG @BBL X1C",
+    "from": "system",
+    "setting_id": "CXPETX04",
+    "instantiation": "true",
+    "filament_flow_ratio": [
+        "0.94"
+    ],
+    "filament_long_retractions_when_cut": [
+        "nil"
+    ],
+    "filament_max_volumetric_speed": [
+        "9"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil"
+    ],
+    "compatible_printers": [
+        "Bambu Lab A1 mini 0.4 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PETG @BBL X1C 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PETG @BBL X1C 0.2 nozzle.json
@@ -1,0 +1,24 @@
+{
+    "type": "filament",
+    "name": "COEX PETG @BBL X1C 0.2 nozzle",
+    "inherits": "COEX PETG @base",
+    "from": "system",
+    "setting_id": "CXPETX03",
+    "instantiation": "true",
+    "filament_max_volumetric_speed": [
+        "6"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "18"
+    ],
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.2 nozzle",
+        "Bambu Lab X1 0.2 nozzle",
+        "Bambu Lab P1P 0.2 nozzle",
+        "Bambu Lab P1S 0.2 nozzle",
+        "Bambu Lab X1E 0.2 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PETG @BBL X1C 0.8 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PETG @BBL X1C 0.8 nozzle.json
@@ -1,0 +1,35 @@
+{
+    "type": "filament",
+    "name": "COEX PETG @BBL X1C 0.8 nozzle",
+    "inherits": "COEX PETG @base",
+    "from": "system",
+    "setting_id": "CXPETX02",
+    "instantiation": "true",
+    "fan_max_speed": [
+        "40"
+    ],
+    "fan_min_speed": [
+        "20"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "18"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ],
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.6 nozzle",
+        "Bambu Lab X1 0.6 nozzle",
+        "Bambu Lab P1P 0.6 nozzle",
+        "Bambu Lab X1 Carbon 0.8 nozzle",
+        "Bambu Lab X1 0.8 nozzle",
+        "Bambu Lab P1P 0.8 nozzle",
+        "Bambu Lab P1S 0.6 nozzle",
+        "Bambu Lab P1S 0.8 nozzle",
+        "Bambu Lab X1E 0.6 nozzle",
+        "Bambu Lab X1E 0.8 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PETG @BBL X1C.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PETG @BBL X1C.json
@@ -1,0 +1,24 @@
+{
+    "type": "filament",
+    "name": "COEX PETG @BBL X1C",
+    "inherits": "COEX PETG @base",
+    "from": "system",
+    "setting_id": "CXPETX01",
+    "instantiation": "true",
+    "filament_max_volumetric_speed": [
+        "14"
+    ],
+    "filament_long_retractions_when_cut": [
+        "1"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "18"
+    ],
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.4 nozzle",
+        "Bambu Lab X1 0.4 nozzle",
+        "Bambu Lab P1P 0.4 nozzle",
+        "Bambu Lab P1S 0.4 nozzle",
+        "Bambu Lab X1E 0.4 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA @BBL A1 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA @BBL A1 0.2 nozzle.json
@@ -1,0 +1,26 @@
+{
+    "type": "filament",
+    "name": "COEX PLA @BBL A1 0.2 nozzle",
+    "inherits": "COEX PLA @base",
+    "from": "system",
+    "setting_id": "CXPLAX09",
+    "instantiation": "true",
+    "fan_cooling_layer_time": [
+        "80"
+    ],
+    "fan_max_speed": [
+        "80"
+    ],
+    "fan_min_speed": [
+        "60"
+    ],
+    "filament_max_volumetric_speed": [
+        "1.6"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "compatible_printers": [
+        "Bambu Lab A1 0.2 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA @BBL A1.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA @BBL A1.json
@@ -1,0 +1,25 @@
+{
+    "type": "filament",
+    "name": "COEX PLA @BBL A1",
+    "inherits": "COEX PLA @base",
+    "from": "system",
+    "setting_id": "CXPLAX08",
+    "instantiation": "true",
+    "fan_cooling_layer_time": [
+        "80"
+    ],
+    "fan_max_speed": [
+        "80"
+    ],
+    "fan_min_speed": [
+        "60"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "compatible_printers": [
+        "Bambu Lab A1 0.4 nozzle",
+        "Bambu Lab A1 0.6 nozzle",
+        "Bambu Lab A1 0.8 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA @BBL A1M 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA @BBL A1M 0.2 nozzle.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "COEX PLA @BBL A1M 0.2 nozzle",
+    "inherits": "COEX PLA @BBL A1M",
+    "from": "system",
+    "setting_id": "CXPLAX07",
+    "instantiation": "true",
+    "filament_max_volumetric_speed": [
+        "6"
+    ],
+    "compatible_printers": [
+        "Bambu Lab A1 mini 0.2 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA @BBL A1M.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA @BBL A1M.json
@@ -1,0 +1,37 @@
+{
+    "type": "filament",
+    "name": "COEX PLA @BBL A1M",
+    "inherits": "COEX PLA @base",
+    "from": "system",
+    "setting_id": "CXPLAX06",
+    "instantiation": "true",
+    "fan_cooling_layer_time": [
+        "80"
+    ],
+    "fan_max_speed": [
+        "80"
+    ],
+    "fan_min_speed": [
+        "60"
+    ],
+    "hot_plate_temp": [
+        "60"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "60"
+    ],
+    "slow_down_layer_time": [
+        "8"
+    ],
+    "textured_plate_temp": [
+        "65"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "65"
+    ],
+    "compatible_printers": [
+        "Bambu Lab A1 mini 0.4 nozzle",
+        "Bambu Lab A1 mini 0.6 nozzle",
+        "Bambu Lab A1 mini 0.8 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA @BBL P1P 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA @BBL P1P 0.2 nozzle.json
@@ -1,0 +1,14 @@
+{
+    "type": "filament",
+    "name": "COEX PLA @BBL P1P 0.2 nozzle",
+    "inherits": "COEX PLA @BBL P1P",
+    "from": "system",
+    "setting_id": "CXPLAX05",
+    "instantiation": "true",
+    "filament_max_volumetric_speed": [
+        "6"
+    ],
+    "compatible_printers": [
+        "Bambu Lab P1P 0.2 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA @BBL P1P.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA @BBL P1P.json
@@ -1,0 +1,22 @@
+{
+    "type": "filament",
+    "name": "COEX PLA @BBL P1P",
+    "inherits": "COEX PLA @base",
+    "from": "system",
+    "setting_id": "CXPLAX04",
+    "instantiation": "true",
+    "fan_cooling_layer_time": [
+        "80"
+    ],
+    "fan_min_speed": [
+        "50"
+    ],
+    "slow_down_layer_time": [
+        "10"
+    ],
+    "compatible_printers": [
+        "Bambu Lab P1P 0.4 nozzle",
+        "Bambu Lab P1P 0.6 nozzle",
+        "Bambu Lab P1P 0.8 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA @BBL X1.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA @BBL X1.json
@@ -1,0 +1,16 @@
+{
+    "type": "filament",
+    "name": "COEX PLA @BBL X1",
+    "inherits": "COEX PLA @base",
+    "from": "system",
+    "setting_id": "CXPLAX03",
+    "instantiation": "true",
+    "slow_down_layer_time": [
+        "10"
+    ],
+    "compatible_printers": [
+        "Bambu Lab X1 0.4 nozzle",
+        "Bambu Lab X1 0.8 nozzle",
+        "Bambu Lab X1 0.6 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA @BBL X1C 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA @BBL X1C 0.2 nozzle.json
@@ -1,0 +1,17 @@
+{
+    "type": "filament",
+    "name": "COEX PLA @BBL X1C 0.2 nozzle",
+    "inherits": "COEX PLA @BBL X1C",
+    "from": "system",
+    "setting_id": "CXPLAX02",
+    "instantiation": "true",
+    "filament_max_volumetric_speed": [
+        "1.6"
+    ],
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.2 nozzle",
+        "Bambu Lab X1 0.2 nozzle",
+        "Bambu Lab P1S 0.2 nozzle",
+        "Bambu Lab X1E 0.2 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA @BBL X1C.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA @BBL X1C.json
@@ -1,0 +1,19 @@
+{
+    "type": "filament",
+    "name": "COEX PLA @BBL X1C",
+    "inherits": "COEX PLA @base",
+    "from": "system",
+    "setting_id": "CXPLAX01",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.4 nozzle",
+        "Bambu Lab X1 Carbon 0.6 nozzle",
+        "Bambu Lab X1 Carbon 0.8 nozzle",
+        "Bambu Lab P1S 0.4 nozzle",
+        "Bambu Lab P1S 0.6 nozzle",
+        "Bambu Lab P1S 0.8 nozzle",
+        "Bambu Lab X1E 0.4 nozzle",
+        "Bambu Lab X1E 0.6 nozzle",
+        "Bambu Lab X1E 0.8 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA PRIME @BBL A1 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA PRIME @BBL A1 0.2 nozzle.json
@@ -1,0 +1,26 @@
+{
+    "type": "filament",
+    "name": "COEX PLA PRIME @BBL A1 0.2 nozzle",
+    "inherits": "COEX PLA PRIME @base",
+    "from": "system",
+    "setting_id": "CXPLPX10",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab A1 0.2 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "6"
+    ],
+    "slow_down_layer_time": [
+        "2"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA PRIME @BBL A1.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA PRIME @BBL A1.json
@@ -1,0 +1,28 @@
+{
+    "type": "filament",
+    "name": "COEX PLA PRIME @BBL A1",
+    "inherits": "COEX PLA PRIME @base",
+    "from": "system",
+    "setting_id": "CXPLPX09",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab A1 0.4 nozzle",
+        "Bambu Lab A1 0.6 nozzle",
+        "Bambu Lab A1 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ],
+    "slow_down_layer_time": [
+        "2"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA PRIME @BBL A1M 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA PRIME @BBL A1M 0.2 nozzle.json
@@ -1,0 +1,26 @@
+{
+    "type": "filament",
+    "name": "COEX PLA PRIME @BBL A1M 0.2 nozzle",
+    "inherits": "COEX PLA PRIME @base",
+    "from": "system",
+    "setting_id": "CXPLPX08",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab A1 mini 0.2 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "6"
+    ],
+    "slow_down_layer_time": [
+        "2"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA PRIME @BBL A1M.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA PRIME @BBL A1M.json
@@ -1,0 +1,28 @@
+{
+    "type": "filament",
+    "name": "COEX PLA PRIME @BBL A1M",
+    "inherits": "COEX PLA PRIME @base",
+    "from": "system",
+    "setting_id": "CXPLPX07",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab A1 mini 0.4 nozzle",
+        "Bambu Lab A1 mini 0.6 nozzle",
+        "Bambu Lab A1 mini 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ],
+    "slow_down_layer_time": [
+        "2"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA PRIME @BBL P1P 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA PRIME @BBL P1P 0.2 nozzle.json
@@ -1,0 +1,23 @@
+{
+    "type": "filament",
+    "name": "COEX PLA PRIME @BBL P1P 0.2 nozzle",
+    "inherits": "COEX PLA PRIME @base",
+    "from": "system",
+    "setting_id": "CXPLPX06",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab P1P 0.2 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "6"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA PRIME @BBL P1P.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA PRIME @BBL P1P.json
@@ -1,0 +1,25 @@
+{
+    "type": "filament",
+    "name": "COEX PLA PRIME @BBL P1P",
+    "inherits": "COEX PLA PRIME @base",
+    "from": "system",
+    "setting_id": "CXPLPX05",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab P1P 0.4 nozzle",
+        "Bambu Lab P1P 0.6 nozzle",
+        "Bambu Lab P1P 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA PRIME @BBL X1 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA PRIME @BBL X1 0.2 nozzle.json
@@ -1,0 +1,23 @@
+{
+    "type": "filament",
+    "name": "COEX PLA PRIME @BBL X1 0.2 nozzle",
+    "inherits": "COEX PLA PRIME @base",
+    "from": "system",
+    "setting_id": "CXPLPX04",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 0.2 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "6"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA PRIME @BBL X1.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA PRIME @BBL X1.json
@@ -1,0 +1,25 @@
+{
+    "type": "filament",
+    "name": "COEX PLA PRIME @BBL X1",
+    "inherits": "COEX PLA PRIME @base",
+    "from": "system",
+    "setting_id": "CXPLPX03",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 0.4 nozzle",
+        "Bambu Lab X1 0.6 nozzle",
+        "Bambu Lab X1 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA PRIME @BBL X1C 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA PRIME @BBL X1C 0.2 nozzle.json
@@ -1,0 +1,25 @@
+{
+    "type": "filament",
+    "name": "COEX PLA PRIME @BBL X1C 0.2 nozzle",
+    "inherits": "COEX PLA PRIME @base",
+    "from": "system",
+    "setting_id": "CXPLPX02",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.2 nozzle",
+        "Bambu Lab P1S 0.2 nozzle",
+        "Bambu Lab X1E 0.2 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "6"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA PRIME @BBL X1C.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA PRIME @BBL X1C.json
@@ -1,0 +1,31 @@
+{
+    "type": "filament",
+    "name": "COEX PLA PRIME @BBL X1C",
+    "inherits": "COEX PLA PRIME @base",
+    "from": "system",
+    "setting_id": "CXPLPX01",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.4 nozzle",
+        "Bambu Lab X1 Carbon 0.6 nozzle",
+        "Bambu Lab X1 Carbon 0.8 nozzle",
+        "Bambu Lab P1S 0.4 nozzle",
+        "Bambu Lab P1S 0.6 nozzle",
+        "Bambu Lab P1S 0.8 nozzle",
+        "Bambu Lab X1E 0.4 nozzle",
+        "Bambu Lab X1E 0.6 nozzle",
+        "Bambu Lab X1E 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA+Silk @BBL A1 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA+Silk @BBL A1 0.2 nozzle.json
@@ -1,0 +1,26 @@
+{
+    "type": "filament",
+    "name": "COEX PLA+Silk @BBL A1 0.2 nozzle",
+    "inherits": "COEX PLA+Silk @base",
+    "from": "system",
+    "setting_id": "CXPLSX10",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab A1 0.2 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "0.95"
+    ],
+    "filament_max_volumetric_speed": [
+        "6"
+    ],
+    "slow_down_layer_time": [
+        "2"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA+Silk @BBL A1.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA+Silk @BBL A1.json
@@ -1,0 +1,28 @@
+{
+    "type": "filament",
+    "name": "COEX PLA+Silk @BBL A1",
+    "inherits": "COEX PLA+Silk @base",
+    "from": "system",
+    "setting_id": "CXPLSX09",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab A1 0.4 nozzle",
+        "Bambu Lab A1 0.6 nozzle",
+        "Bambu Lab A1 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "0.95"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ],
+    "slow_down_layer_time": [
+        "2"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA+Silk @BBL A1M 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA+Silk @BBL A1M 0.2 nozzle.json
@@ -1,0 +1,26 @@
+{
+    "type": "filament",
+    "name": "COEX PLA+Silk @BBL A1M 0.2 nozzle",
+    "inherits": "COEX PLA+Silk @base",
+    "from": "system",
+    "setting_id": "CXPLSX08",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab A1 mini 0.2 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "0.95"
+    ],
+    "filament_max_volumetric_speed": [
+        "6"
+    ],
+    "slow_down_layer_time": [
+        "2"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA+Silk @BBL A1M.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA+Silk @BBL A1M.json
@@ -1,0 +1,28 @@
+{
+    "type": "filament",
+    "name": "COEX PLA+Silk @BBL A1M",
+    "inherits": "COEX PLA+Silk @base",
+    "from": "system",
+    "setting_id": "CXPLSX07",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab A1 mini 0.4 nozzle",
+        "Bambu Lab A1 mini 0.6 nozzle",
+        "Bambu Lab A1 mini 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "0.95"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ],
+    "slow_down_layer_time": [
+        "2"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA+Silk @BBL P1P 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA+Silk @BBL P1P 0.2 nozzle.json
@@ -1,0 +1,23 @@
+{
+    "type": "filament",
+    "name": "COEX PLA+Silk @BBL P1P 0.2 nozzle",
+    "inherits": "COEX PLA+Silk @base",
+    "from": "system",
+    "setting_id": "CXPLSX06",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab P1P 0.2 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "0.95"
+    ],
+    "filament_max_volumetric_speed": [
+        "6"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA+Silk @BBL P1P.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA+Silk @BBL P1P.json
@@ -1,0 +1,25 @@
+{
+    "type": "filament",
+    "name": "COEX PLA+Silk @BBL P1P",
+    "inherits": "COEX PLA+Silk @base",
+    "from": "system",
+    "setting_id": "CXPLSX05",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab P1P 0.4 nozzle",
+        "Bambu Lab P1P 0.6 nozzle",
+        "Bambu Lab P1P 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "0.95"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA+Silk @BBL X1 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA+Silk @BBL X1 0.2 nozzle.json
@@ -1,0 +1,23 @@
+{
+    "type": "filament",
+    "name": "COEX PLA+Silk @BBL X1 0.2 nozzle",
+    "inherits": "COEX PLA+Silk @base",
+    "from": "system",
+    "setting_id": "CXPLSX04",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 0.2 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "0.95"
+    ],
+    "filament_max_volumetric_speed": [
+        "6"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA+Silk @BBL X1.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA+Silk @BBL X1.json
@@ -1,0 +1,25 @@
+{
+    "type": "filament",
+    "name": "COEX PLA+Silk @BBL X1",
+    "inherits": "COEX PLA+Silk @base",
+    "from": "system",
+    "setting_id": "CXPLSX03",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 0.4 nozzle",
+        "Bambu Lab X1 0.6 nozzle",
+        "Bambu Lab X1 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "0.95"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA+Silk @BBL X1C 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA+Silk @BBL X1C 0.2 nozzle.json
@@ -1,0 +1,25 @@
+{
+    "type": "filament",
+    "name": "COEX PLA+Silk @BBL X1C 0.2 nozzle",
+    "inherits": "COEX PLA+Silk @base",
+    "from": "system",
+    "setting_id": "CXPLSX02",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.2 nozzle",
+        "Bambu Lab P1S 0.2 nozzle",
+        "Bambu Lab X1E 0.2 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "0.95"
+    ],
+    "filament_max_volumetric_speed": [
+        "6"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX PLA+Silk @BBL X1C.json
+++ b/resources/profiles/BBL/filament/COEX/COEX PLA+Silk @BBL X1C.json
@@ -1,0 +1,31 @@
+{
+    "type": "filament",
+    "name": "COEX PLA+Silk @BBL X1C",
+    "inherits": "COEX PLA+Silk @base",
+    "from": "system",
+    "setting_id": "CXPLSX01",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.4 nozzle",
+        "Bambu Lab X1 Carbon 0.6 nozzle",
+        "Bambu Lab X1 Carbon 0.8 nozzle",
+        "Bambu Lab P1S 0.4 nozzle",
+        "Bambu Lab P1S 0.6 nozzle",
+        "Bambu Lab P1S 0.8 nozzle",
+        "Bambu Lab X1E 0.4 nozzle",
+        "Bambu Lab X1E 0.6 nozzle",
+        "Bambu Lab X1E 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "0.95"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX TPE 30D @BBL A1.json
+++ b/resources/profiles/BBL/filament/COEX/COEX TPE 30D @BBL A1.json
@@ -1,0 +1,25 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 30D @BBL A1",
+    "inherits": "COEX TPE 30D @base",
+    "from": "system",
+    "setting_id": "CX30DX09",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab A1 0.4 nozzle",
+        "Bambu Lab A1 0.6 nozzle",
+        "Bambu Lab A1 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "3.5"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX TPE 30D @BBL A1M.json
+++ b/resources/profiles/BBL/filament/COEX/COEX TPE 30D @BBL A1M.json
@@ -1,0 +1,25 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 30D @BBL A1M",
+    "inherits": "COEX TPE 30D @base",
+    "from": "system",
+    "setting_id": "CX30DX07",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab A1 mini 0.4 nozzle",
+        "Bambu Lab A1 mini 0.6 nozzle",
+        "Bambu Lab A1 mini 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "3.5"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX TPE 30D @BBL P1P.json
+++ b/resources/profiles/BBL/filament/COEX/COEX TPE 30D @BBL P1P.json
@@ -1,0 +1,25 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 30D @BBL P1P",
+    "inherits": "COEX TPE 30D @base",
+    "from": "system",
+    "setting_id": "CX30DX05",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab P1P 0.4 nozzle",
+        "Bambu Lab P1P 0.6 nozzle",
+        "Bambu Lab P1P 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "3.5"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX TPE 30D @BBL X1.json
+++ b/resources/profiles/BBL/filament/COEX/COEX TPE 30D @BBL X1.json
@@ -1,0 +1,25 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 30D @BBL X1",
+    "inherits": "COEX TPE 30D @base",
+    "from": "system",
+    "setting_id": "CX30DX03",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 0.4 nozzle",
+        "Bambu Lab X1 0.6 nozzle",
+        "Bambu Lab X1 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "3.5"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX TPE 30D @BBL X1C.json
+++ b/resources/profiles/BBL/filament/COEX/COEX TPE 30D @BBL X1C.json
@@ -1,0 +1,31 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 30D @BBL X1C",
+    "inherits": "COEX TPE 30D @base",
+    "from": "system",
+    "setting_id": "CX30DX01",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.4 nozzle",
+        "Bambu Lab X1 Carbon 0.6 nozzle",
+        "Bambu Lab X1 Carbon 0.8 nozzle",
+        "Bambu Lab P1S 0.4 nozzle",
+        "Bambu Lab P1S 0.6 nozzle",
+        "Bambu Lab P1S 0.8 nozzle",
+        "Bambu Lab X1E 0.4 nozzle",
+        "Bambu Lab X1E 0.6 nozzle",
+        "Bambu Lab X1E 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "3.5"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX TPE 40D @BBL A1 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX TPE 40D @BBL A1 0.2 nozzle.json
@@ -1,0 +1,23 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 40D @BBL A1 0.2 nozzle",
+    "inherits": "COEX TPE 40D @base",
+    "from": "system",
+    "setting_id": "CX40DX10",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab A1 0.2 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "1.6"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX TPE 40D @BBL A1.json
+++ b/resources/profiles/BBL/filament/COEX/COEX TPE 40D @BBL A1.json
@@ -1,0 +1,25 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 40D @BBL A1",
+    "inherits": "COEX TPE 40D @base",
+    "from": "system",
+    "setting_id": "CX40DX09",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab A1 0.4 nozzle",
+        "Bambu Lab A1 0.6 nozzle",
+        "Bambu Lab A1 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "5.5"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX TPE 40D @BBL A1M 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX TPE 40D @BBL A1M 0.2 nozzle.json
@@ -1,0 +1,23 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 40D @BBL A1M 0.2 nozzle",
+    "inherits": "COEX TPE 40D @base",
+    "from": "system",
+    "setting_id": "CX40DX08",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab A1 mini 0.2 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "1.6"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX TPE 40D @BBL A1M.json
+++ b/resources/profiles/BBL/filament/COEX/COEX TPE 40D @BBL A1M.json
@@ -1,0 +1,25 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 40D @BBL A1M",
+    "inherits": "COEX TPE 40D @base",
+    "from": "system",
+    "setting_id": "CX40DX07",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab A1 mini 0.4 nozzle",
+        "Bambu Lab A1 mini 0.6 nozzle",
+        "Bambu Lab A1 mini 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "5.5"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX TPE 40D @BBL P1P 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX TPE 40D @BBL P1P 0.2 nozzle.json
@@ -1,0 +1,23 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 40D @BBL P1P 0.2 nozzle",
+    "inherits": "COEX TPE 40D @base",
+    "from": "system",
+    "setting_id": "CX40DX06",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab P1P 0.2 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "1.6"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX TPE 40D @BBL P1P.json
+++ b/resources/profiles/BBL/filament/COEX/COEX TPE 40D @BBL P1P.json
@@ -1,0 +1,25 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 40D @BBL P1P",
+    "inherits": "COEX TPE 40D @base",
+    "from": "system",
+    "setting_id": "CX40DX05",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab P1P 0.4 nozzle",
+        "Bambu Lab P1P 0.6 nozzle",
+        "Bambu Lab P1P 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "5.5"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX TPE 40D @BBL X1 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX TPE 40D @BBL X1 0.2 nozzle.json
@@ -1,0 +1,23 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 40D @BBL X1 0.2 nozzle",
+    "inherits": "COEX TPE 40D @base",
+    "from": "system",
+    "setting_id": "CX40DX04",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 0.2 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "1.6"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX TPE 40D @BBL X1.json
+++ b/resources/profiles/BBL/filament/COEX/COEX TPE 40D @BBL X1.json
@@ -1,0 +1,25 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 40D @BBL X1",
+    "inherits": "COEX TPE 40D @base",
+    "from": "system",
+    "setting_id": "CX40DX03",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 0.4 nozzle",
+        "Bambu Lab X1 0.6 nozzle",
+        "Bambu Lab X1 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "5.5"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX TPE 40D @BBL X1C 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX TPE 40D @BBL X1C 0.2 nozzle.json
@@ -1,0 +1,25 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 40D @BBL X1C 0.2 nozzle",
+    "inherits": "COEX TPE 40D @base",
+    "from": "system",
+    "setting_id": "CX40DX02",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.2 nozzle",
+        "Bambu Lab P1S 0.2 nozzle",
+        "Bambu Lab X1E 0.2 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "1.6"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX TPE 40D @BBL X1C.json
+++ b/resources/profiles/BBL/filament/COEX/COEX TPE 40D @BBL X1C.json
@@ -1,0 +1,31 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 40D @BBL X1C",
+    "inherits": "COEX TPE 40D @base",
+    "from": "system",
+    "setting_id": "CX40DX01",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.4 nozzle",
+        "Bambu Lab X1 Carbon 0.6 nozzle",
+        "Bambu Lab X1 Carbon 0.8 nozzle",
+        "Bambu Lab P1S 0.4 nozzle",
+        "Bambu Lab P1S 0.6 nozzle",
+        "Bambu Lab P1S 0.8 nozzle",
+        "Bambu Lab X1E 0.4 nozzle",
+        "Bambu Lab X1E 0.6 nozzle",
+        "Bambu Lab X1E 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "5.5"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX TPE 60D @BBL A1 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX TPE 60D @BBL A1 0.2 nozzle.json
@@ -1,0 +1,23 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 60D @BBL A1 0.2 nozzle",
+    "inherits": "COEX TPE 60D @base",
+    "from": "system",
+    "setting_id": "CX60DX10",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab A1 0.2 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "1.6"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX TPE 60D @BBL A1.json
+++ b/resources/profiles/BBL/filament/COEX/COEX TPE 60D @BBL A1.json
@@ -1,0 +1,25 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 60D @BBL A1",
+    "inherits": "COEX TPE 60D @base",
+    "from": "system",
+    "setting_id": "CX60DX09",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab A1 0.4 nozzle",
+        "Bambu Lab A1 0.6 nozzle",
+        "Bambu Lab A1 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "6.5"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX TPE 60D @BBL A1M 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX TPE 60D @BBL A1M 0.2 nozzle.json
@@ -1,0 +1,23 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 60D @BBL A1M 0.2 nozzle",
+    "inherits": "COEX TPE 60D @base",
+    "from": "system",
+    "setting_id": "CX60DX08",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab A1 mini 0.2 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "1.6"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX TPE 60D @BBL A1M.json
+++ b/resources/profiles/BBL/filament/COEX/COEX TPE 60D @BBL A1M.json
@@ -1,0 +1,25 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 60D @BBL A1M",
+    "inherits": "COEX TPE 60D @base",
+    "from": "system",
+    "setting_id": "CX60DX07",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab A1 mini 0.4 nozzle",
+        "Bambu Lab A1 mini 0.6 nozzle",
+        "Bambu Lab A1 mini 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "6.5"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX TPE 60D @BBL P1P 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX TPE 60D @BBL P1P 0.2 nozzle.json
@@ -1,0 +1,23 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 60D @BBL P1P 0.2 nozzle",
+    "inherits": "COEX TPE 60D @base",
+    "from": "system",
+    "setting_id": "CX60DX06",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab P1P 0.2 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "1.6"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX TPE 60D @BBL P1P.json
+++ b/resources/profiles/BBL/filament/COEX/COEX TPE 60D @BBL P1P.json
@@ -1,0 +1,25 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 60D @BBL P1P",
+    "inherits": "COEX TPE 60D @base",
+    "from": "system",
+    "setting_id": "CX60DX05",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab P1P 0.4 nozzle",
+        "Bambu Lab P1P 0.6 nozzle",
+        "Bambu Lab P1P 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "6.5"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX TPE 60D @BBL X1 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX TPE 60D @BBL X1 0.2 nozzle.json
@@ -1,0 +1,23 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 60D @BBL X1 0.2 nozzle",
+    "inherits": "COEX TPE 60D @base",
+    "from": "system",
+    "setting_id": "CX60DX04",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 0.2 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "1.6"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX TPE 60D @BBL X1.json
+++ b/resources/profiles/BBL/filament/COEX/COEX TPE 60D @BBL X1.json
@@ -1,0 +1,25 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 60D @BBL X1",
+    "inherits": "COEX TPE 60D @base",
+    "from": "system",
+    "setting_id": "CX60DX03",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 0.4 nozzle",
+        "Bambu Lab X1 0.6 nozzle",
+        "Bambu Lab X1 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "6.5"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX TPE 60D @BBL X1C 0.2 nozzle.json
+++ b/resources/profiles/BBL/filament/COEX/COEX TPE 60D @BBL X1C 0.2 nozzle.json
@@ -1,0 +1,25 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 60D @BBL X1C 0.2 nozzle",
+    "inherits": "COEX TPE 60D @base",
+    "from": "system",
+    "setting_id": "CX60DX02",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.2 nozzle",
+        "Bambu Lab P1S 0.2 nozzle",
+        "Bambu Lab X1E 0.2 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "1.6"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX TPE 60D @BBL X1C.json
+++ b/resources/profiles/BBL/filament/COEX/COEX TPE 60D @BBL X1C.json
@@ -1,0 +1,31 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 60D @BBL X1C",
+    "inherits": "COEX TPE 60D @base",
+    "from": "system",
+    "setting_id": "CX60DX01",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.4 nozzle",
+        "Bambu Lab X1 Carbon 0.6 nozzle",
+        "Bambu Lab X1 Carbon 0.8 nozzle",
+        "Bambu Lab P1S 0.4 nozzle",
+        "Bambu Lab P1S 0.6 nozzle",
+        "Bambu Lab P1S 0.8 nozzle",
+        "Bambu Lab X1E 0.4 nozzle",
+        "Bambu Lab X1E 0.6 nozzle",
+        "Bambu Lab X1E 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "6.5"
+    ]
+}

--- a/resources/profiles/BBL/filament/COEX/COEX TPU 60A @BBL X1C.json
+++ b/resources/profiles/BBL/filament/COEX/COEX TPU 60A @BBL X1C.json
@@ -1,0 +1,31 @@
+{
+    "type": "filament",
+    "name": "COEX TPU 60A @BBL X1C",
+    "inherits": "COEX TPU 60A @base",
+    "from": "system",
+    "setting_id": "CX60AX01",
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.4 nozzle",
+        "Bambu Lab X1 Carbon 0.6 nozzle",
+        "Bambu Lab X1 Carbon 0.8 nozzle",
+        "Bambu Lab P1S 0.4 nozzle",
+        "Bambu Lab P1S 0.6 nozzle",
+        "Bambu Lab P1S 0.8 nozzle",
+        "Bambu Lab X1E 0.4 nozzle",
+        "Bambu Lab X1E 0.6 nozzle",
+        "Bambu Lab X1E 0.8 nozzle"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "1"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary.json
+++ b/resources/profiles/OrcaFilamentLibrary.json
@@ -101,6 +101,14 @@
             "sub_path": "filament/Bambu/Bambu Support for ABS @base.json"
         },
         {
+            "name": "COEX ABS @base",
+            "sub_path": "filament/COEX/COEX ABS @base.json"
+        },
+        {
+            "name": "COEX ABS PRIME @base",
+            "sub_path": "filament/COEX/COEX ABS PRIME @base.json"
+        },
+        {
             "name": "FDplast ABS @base",
             "sub_path": "filament/FDplast/FDplast ABS @base.json"
         },
@@ -131,6 +139,10 @@
         {
             "name": "Bambu ASA-CF @base",
             "sub_path": "filament/Bambu/Bambu ASA-CF @base.json"
+        },
+        {
+            "name": "COEX ASA PRIME @base",
+            "sub_path": "filament/COEX/COEX ASA PRIME @base.json"
         },
         {
             "name": "Generic ASA @System",
@@ -189,6 +201,14 @@
             "sub_path": "filament/Bambu/Bambu Support G @base.json"
         },
         {
+            "name": "COEX NYLEX PA6-CF @base",
+            "sub_path": "filament/COEX/COEX NYLEX PA6-CF @base.json"
+        },
+        {
+            "name": "COEX NYLEX UNFILLED @base",
+            "sub_path": "filament/COEX/COEX NYLEX UNFILLED @base.json"
+        },
+        {
             "name": "Fiberon PA12-CF @base",
             "sub_path": "filament/Polymaker/Fiberon PA12-CF @base.json"
         },
@@ -225,6 +245,10 @@
             "sub_path": "filament/Generic PC @System.json"
         },
         {
+            "name": "COEX PCTG PRIME @base",
+            "sub_path": "filament/COEX/COEX PCTG PRIME @base.json"
+        },
+        {
             "name": "Generic PCTG @System",
             "sub_path": "filament/Generic PCTG @System.json"
         },
@@ -259,6 +283,10 @@
         {
             "name": "Bambu PETG-CF @base",
             "sub_path": "filament/Bambu/Bambu PETG-CF @base.json"
+        },
+        {
+            "name": "COEX PETG @base",
+            "sub_path": "filament/COEX/COEX PETG @base.json"
         },
         {
             "name": "FDplast PETG @base",
@@ -383,6 +411,14 @@
         {
             "name": "Bambu Support W @base",
             "sub_path": "filament/Bambu/Bambu Support W @base.json"
+        },
+        {
+            "name": "COEX PLA @base",
+            "sub_path": "filament/COEX/COEX PLA @base.json"
+        },
+        {
+            "name": "COEX PLA PRIME @base",
+            "sub_path": "filament/COEX/COEX PLA PRIME @base.json"
         },
         {
             "name": "FDplast PLA @base",
@@ -629,6 +665,22 @@
             "sub_path": "filament/Bambu/Bambu TPU 95A HF @base.json"
         },
         {
+            "name": "COEX TPE 30D @base",
+            "sub_path": "filament/COEX/COEX TPE 30D @base.json"
+        },
+        {
+            "name": "COEX TPE 40D @base",
+            "sub_path": "filament/COEX/COEX TPE 40D @base.json"
+        },
+        {
+            "name": "COEX TPE 60D @base",
+            "sub_path": "filament/COEX/COEX TPE 60D @base.json"
+        },
+        {
+            "name": "COEX TPU 60A @base",
+            "sub_path": "filament/COEX/COEX TPU 60A @base.json"
+        },
+        {
             "name": "FDplast TPU @base",
             "sub_path": "filament/FDplast/FDplast TPU @base.json"
         },
@@ -651,6 +703,14 @@
         {
             "name": "Bambu Support for ABS @System",
             "sub_path": "filament/Bambu/Bambu Support for ABS @System.json"
+        },
+        {
+            "name": "COEX ABS @System",
+            "sub_path": "filament/COEX/COEX ABS @System.json"
+        },
+        {
+            "name": "COEX ABS PRIME @System",
+            "sub_path": "filament/COEX/COEX ABS PRIME @System.json"
         },
         {
             "name": "FDplast ABS @System",
@@ -679,6 +739,10 @@
         {
             "name": "Bambu ASA-CF @System",
             "sub_path": "filament/Bambu/Bambu ASA-CF @System.json"
+        },
+        {
+            "name": "COEX ASA PRIME @System",
+            "sub_path": "filament/COEX/COEX ASA PRIME @System.json"
         },
         {
             "name": "Overture ASA @System",
@@ -721,6 +785,10 @@
             "sub_path": "filament/Bambu/Bambu Support G @System.json"
         },
         {
+            "name": "COEX NYLEX PA6-CF @System",
+            "sub_path": "filament/COEX/COEX NYLEX PA6-CF @System.json"
+        },
+        {
             "name": "Fiberon PA12-CF @System",
             "sub_path": "filament/Polymaker/Fiberon PA12-CF @System.json"
         },
@@ -743,6 +811,10 @@
         {
             "name": "Bambu PC FR @System",
             "sub_path": "filament/Bambu/Bambu PC FR @System.json"
+        },
+        {
+            "name": "COEX PCTG PRIME @System",
+            "sub_path": "filament/COEX/COEX PCTG PRIME @System.json"
         },
         {
             "name": "AliZ PETG @System",
@@ -775,6 +847,10 @@
         {
             "name": "Bambu PETG-CF @System",
             "sub_path": "filament/Bambu/Bambu PETG-CF @System.json"
+        },
+        {
+            "name": "COEX PETG @System",
+            "sub_path": "filament/COEX/COEX PETG @System.json"
         },
         {
             "name": "FDplast PETG @System",
@@ -883,6 +959,14 @@
         {
             "name": "Bambu Support W @System",
             "sub_path": "filament/Bambu/Bambu Support W @System.json"
+        },
+        {
+            "name": "COEX PLA @System",
+            "sub_path": "filament/COEX/COEX PLA @System.json"
+        },
+        {
+            "name": "COEX PLA PRIME @System",
+            "sub_path": "filament/COEX/COEX PLA PRIME @System.json"
         },
         {
             "name": "FDplast PLA @System",
@@ -1061,6 +1145,10 @@
             "sub_path": "filament/eSUN/eSUN PLA+ @System.json"
         },
         {
+            "name": "COEX PLA+Silk @base",
+            "sub_path": "filament/COEX/COEX PLA+Silk @base.json"
+        },
+        {
             "name": "Generic PLA Silk @System",
             "sub_path": "filament/Generic PLA Silk @System.json"
         },
@@ -1085,6 +1173,22 @@
             "sub_path": "filament/Bambu/Bambu TPU 95A HF @System.json"
         },
         {
+            "name": "COEX TPE 30D @System",
+            "sub_path": "filament/COEX/COEX TPE 30D @System.json"
+        },
+        {
+            "name": "COEX TPE 40D @System",
+            "sub_path": "filament/COEX/COEX TPE 40D @System.json"
+        },
+        {
+            "name": "COEX TPE 60D @System",
+            "sub_path": "filament/COEX/COEX TPE 60D @System.json"
+        },
+        {
+            "name": "COEX TPU 60A @System",
+            "sub_path": "filament/COEX/COEX TPU 60A @System.json"
+        },
+        {
             "name": "FDplast TPU @System",
             "sub_path": "filament/FDplast/FDplast TPU @System.json"
         },
@@ -1099,6 +1203,10 @@
         {
             "name": "AliZ PETG-Metal @System",
             "sub_path": "filament/AliZ/AliZ PETG-Metal @System.json"
+        },
+        {
+            "name": "COEX PLA+Silk @System",
+            "sub_path": "filament/COEX/COEX PLA+Silk @System.json"
         }
     ],
     "process_list": [],

--- a/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX ABS @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX ABS @System.json
@@ -1,0 +1,18 @@
+{
+    "type": "filament",
+    "name": "COEX ABS @System",
+    "inherits": "COEX ABS @base",
+    "from": "system",
+    "setting_id": "COXABS01",
+    "instantiation": "true",
+    "filament_max_volumetric_speed": [
+        "16"
+    ],
+    "filament_long_retractions_when_cut": [
+        "nil"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil"
+    ],
+    "compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX ABS @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX ABS @base.json
@@ -1,0 +1,96 @@
+{
+    "type": "filament",
+    "name": "COEX ABS @base",
+    "inherits": "fdm_filament_abs",
+    "from": "system",
+    "filament_id": "CXABSB01",
+    "instantiation": "false",
+    "filament_vendor": [
+        "COEX 3D"
+    ],
+    "filament_cost": [
+        "30.00"
+    ],
+    "filament_density": [
+        "1.04"
+    ],
+    "filament_type": [
+        "ABS"
+    ],
+    "nozzle_temperature": [
+        "255"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "255"
+    ],
+    "bed_temperature": [
+        "100"
+    ],
+    "bed_temperature_initial_layer": [
+        "100"
+    ],
+    "temperature_vitrification": [
+        "100"
+    ],
+    "chamber_temperature": [
+        "0"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ],
+    "filament_retraction_minimum_travel": [
+        "2"
+    ],
+    "filament_retract_before_wipe": [
+        "70%"
+    ],
+    "filament_retract_layer_change": [
+        "1"
+    ],
+    "filament_retract_when_changing_layer": [
+        "1"
+    ],
+    "filament_retraction_length": [
+        "2.5"
+    ],
+    "filament_retraction_speed": [
+        "40"
+    ],
+    "filament_deretraction_speed": [
+        "40"
+    ],
+    "filament_wipe": [
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "2"
+    ],
+    "fan_min_speed": [
+        "0"
+    ],
+    "fan_max_speed": [
+        "30"
+    ],
+    "disable_fan_first_layers": [
+        "3"
+    ],
+    "full_fan_speed_layer": [
+        "0"
+    ],
+    "slow_down_layer_time": [
+        "5"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "enable_pressure_advance": [
+        "1"
+    ],
+    "pressure_advance": [
+        "0.04"
+    ],
+    "compatible_printers": [],
+    "compatible_printers_condition": "",
+    "compatible_prints": [],
+    "compatible_prints_condition": ""
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX ABS PRIME @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX ABS PRIME @System.json
@@ -1,0 +1,18 @@
+{
+    "type": "filament",
+    "name": "COEX ABS PRIME @System",
+    "inherits": "COEX ABS PRIME @base",
+    "from": "system",
+    "setting_id": "CXABSP09",
+    "instantiation": "true",
+    "filament_max_volumetric_speed": [
+        "16"
+    ],
+    "filament_long_retractions_when_cut": [
+        "nil"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil"
+    ],
+    "compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX ABS PRIME @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX ABS PRIME @base.json
@@ -1,0 +1,96 @@
+{
+    "type": "filament",
+    "name": "COEX ABS PRIME @base",
+    "inherits": "fdm_filament_abs",
+    "from": "system",
+    "filament_id": "CXABPB09",
+    "instantiation": "false",
+    "filament_vendor": [
+        "COEX 3D"
+    ],
+    "filament_cost": [
+        "39.00"
+    ],
+    "filament_density": [
+        "1.04"
+    ],
+    "filament_type": [
+        "ABS"
+    ],
+    "nozzle_temperature": [
+        "255"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "255"
+    ],
+    "bed_temperature": [
+        "100"
+    ],
+    "bed_temperature_initial_layer": [
+        "100"
+    ],
+    "temperature_vitrification": [
+        "100"
+    ],
+    "chamber_temperature": [
+        "0"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ],
+    "filament_retraction_minimum_travel": [
+        "2"
+    ],
+    "filament_retract_before_wipe": [
+        "70%"
+    ],
+    "filament_retract_layer_change": [
+        "1"
+    ],
+    "filament_retract_when_changing_layer": [
+        "1"
+    ],
+    "filament_retraction_length": [
+        "2.5"
+    ],
+    "filament_retraction_speed": [
+        "40"
+    ],
+    "filament_deretraction_speed": [
+        "40"
+    ],
+    "filament_wipe": [
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "2"
+    ],
+    "fan_min_speed": [
+        "0"
+    ],
+    "fan_max_speed": [
+        "30"
+    ],
+    "disable_fan_first_layers": [
+        "3"
+    ],
+    "full_fan_speed_layer": [
+        "0"
+    ],
+    "slow_down_layer_time": [
+        "5"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "enable_pressure_advance": [
+        "1"
+    ],
+    "pressure_advance": [
+        "0.04"
+    ],
+    "compatible_printers": [],
+    "compatible_printers_condition": "",
+    "compatible_prints": [],
+    "compatible_prints_condition": ""
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX ASA PRIME @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX ASA PRIME @System.json
@@ -1,0 +1,18 @@
+{
+    "type": "filament",
+    "name": "COEX ASA PRIME @System",
+    "inherits": "COEX ASA PRIME @base",
+    "from": "system",
+    "setting_id": "CXASAP04",
+    "instantiation": "true",
+    "filament_max_volumetric_speed": [
+        "16"
+    ],
+    "filament_long_retractions_when_cut": [
+        "nil"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil"
+    ],
+    "compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX ASA PRIME @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX ASA PRIME @base.json
@@ -1,0 +1,97 @@
+{
+    "type": "filament",
+    "name": "COEX ASA PRIME @base",
+    "inherits": "fdm_filament_asa",
+    "from": "system",
+    "filament_id": "CXASAB04",
+    "instantiation": "false",
+    "filament_vendor": [
+        "COEX 3D"
+    ],
+    "filament_cost": [
+        "34.00"
+    ],
+    "filament_density": [
+        "1.07"
+    ],
+    "filament_type": [
+        "ASA"
+    ],
+    "filament_notes": "UV and weather resistant - requires good ventilation",
+    "nozzle_temperature": [
+        "265"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "265"
+    ],
+    "bed_temperature": [
+        "100"
+    ],
+    "bed_temperature_initial_layer": [
+        "100"
+    ],
+    "temperature_vitrification": [
+        "95"
+    ],
+    "chamber_temperature": [
+        "0"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ],
+    "filament_retraction_minimum_travel": [
+        "2"
+    ],
+    "filament_retract_before_wipe": [
+        "70%"
+    ],
+    "filament_retract_layer_change": [
+        "1"
+    ],
+    "filament_retract_when_changing_layer": [
+        "1"
+    ],
+    "filament_retraction_length": [
+        "2.5"
+    ],
+    "filament_retraction_speed": [
+        "40"
+    ],
+    "filament_deretraction_speed": [
+        "40"
+    ],
+    "filament_wipe": [
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "2"
+    ],
+    "fan_min_speed": [
+        "0"
+    ],
+    "fan_max_speed": [
+        "30"
+    ],
+    "disable_fan_first_layers": [
+        "3"
+    ],
+    "full_fan_speed_layer": [
+        "0"
+    ],
+    "slow_down_layer_time": [
+        "5"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "enable_pressure_advance": [
+        "1"
+    ],
+    "pressure_advance": [
+        "0.04"
+    ],
+    "compatible_printers": [],
+    "compatible_printers_condition": "",
+    "compatible_prints": [],
+    "compatible_prints_condition": ""
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX NYLEX PA6-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX NYLEX PA6-CF @System.json
@@ -1,0 +1,18 @@
+{
+    "type": "filament",
+    "name": "COEX NYLEX PA6-CF @System",
+    "inherits": "COEX NYLEX PA6-CF @base",
+    "from": "system",
+    "setting_id": "CXPACF23",
+    "instantiation": "true",
+    "filament_max_volumetric_speed": [
+        "11"
+    ],
+    "filament_long_retractions_when_cut": [
+        "nil"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil"
+    ],
+    "compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX NYLEX PA6-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX NYLEX PA6-CF @base.json
@@ -1,0 +1,96 @@
+{
+    "type": "filament",
+    "name": "COEX NYLEX PA6-CF @base",
+    "inherits": "fdm_filament_pa",
+    "from": "system",
+    "filament_id": "CXPACB23",
+    "instantiation": "false",
+    "filament_vendor": [
+        "COEX 3D"
+    ],
+    "filament_cost": [
+        "85.00"
+    ],
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_type": [
+        "PA-CF"
+    ],
+    "nozzle_temperature": [
+        "285"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "285"
+    ],
+    "bed_temperature": [
+        "100"
+    ],
+    "bed_temperature_initial_layer": [
+        "100"
+    ],
+    "temperature_vitrification": [
+        "170"
+    ],
+    "chamber_temperature": [
+        "60"
+    ],
+    "filament_max_volumetric_speed": [
+        "11"
+    ],
+    "filament_retraction_minimum_travel": [
+        "2"
+    ],
+    "filament_retract_before_wipe": [
+        "70%"
+    ],
+    "filament_retract_layer_change": [
+        "1"
+    ],
+    "filament_retract_when_changing_layer": [
+        "1"
+    ],
+    "filament_retraction_length": [
+        "2.5"
+    ],
+    "filament_retraction_speed": [
+        "40"
+    ],
+    "filament_deretraction_speed": [
+        "40"
+    ],
+    "filament_wipe": [
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "2"
+    ],
+    "fan_min_speed": [
+        "0"
+    ],
+    "fan_max_speed": [
+        "30"
+    ],
+    "disable_fan_first_layers": [
+        "4"
+    ],
+    "full_fan_speed_layer": [
+        "0"
+    ],
+    "slow_down_layer_time": [
+        "5"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "enable_pressure_advance": [
+        "1"
+    ],
+    "pressure_advance": [
+        "0.02"
+    ],
+    "compatible_printers": [],
+    "compatible_printers_condition": "",
+    "compatible_prints": [],
+    "compatible_prints_condition": ""
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX NYLEX UNFILLED @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX NYLEX UNFILLED @System.json
@@ -1,0 +1,18 @@
+{
+    "type": "filament",
+    "name": "COEX NYLEX PA6-CF @System",
+    "inherits": "COEX NYLEX PA6-CF @base",
+    "from": "system",
+    "setting_id": "CXPAUN21",
+    "instantiation": "true",
+    "filament_max_volumetric_speed": [
+        "11"
+    ],
+    "filament_long_retractions_when_cut": [
+        "nil"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil"
+    ],
+    "compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX NYLEX UNFILLED @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX NYLEX UNFILLED @base.json
@@ -1,0 +1,96 @@
+{
+    "type": "filament",
+    "name": "COEX NYLEX UNFILLED @base",
+    "inherits": "fdm_filament_pa",
+    "from": "system",
+    "filament_id": "CXPAUB21",
+    "instantiation": "false",
+    "filament_vendor": [
+        "COEX 3D"
+    ],
+    "filament_cost": [
+        "85.00"
+    ],
+    "filament_density": [
+        "1.08"
+    ],
+    "filament_type": [
+        "PA"
+    ],
+    "nozzle_temperature": [
+        "260"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "260"
+    ],
+    "bed_temperature": [
+        "100"
+    ],
+    "bed_temperature_initial_layer": [
+        "100"
+    ],
+    "temperature_vitrification": [
+        "100"
+    ],
+    "chamber_temperature": [
+        "0"
+    ],
+    "filament_max_volumetric_speed": [
+        "11"
+    ],
+    "filament_retraction_minimum_travel": [
+        "2"
+    ],
+    "filament_retract_before_wipe": [
+        "70%"
+    ],
+    "filament_retract_layer_change": [
+        "1"
+    ],
+    "filament_retract_when_changing_layer": [
+        "1"
+    ],
+    "filament_retraction_length": [
+        "2.5"
+    ],
+    "filament_retraction_speed": [
+        "40"
+    ],
+    "filament_deretraction_speed": [
+        "40"
+    ],
+    "filament_wipe": [
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "2"
+    ],
+    "fan_min_speed": [
+        "0"
+    ],
+    "fan_max_speed": [
+        "30"
+    ],
+    "disable_fan_first_layers": [
+        "4"
+    ],
+    "full_fan_speed_layer": [
+        "0"
+    ],
+    "slow_down_layer_time": [
+        "5"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "enable_pressure_advance": [
+        "1"
+    ],
+    "pressure_advance": [
+        "0.02"
+    ],
+    "compatible_printers": [],
+    "compatible_printers_condition": "",
+    "compatible_prints": [],
+    "compatible_prints_condition": ""
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX PCTG PRIME @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX PCTG PRIME @System.json
@@ -1,0 +1,18 @@
+{
+    "type": "filament",
+    "name": "COEX PCTG PRIME @System",
+    "inherits": "COEX PCTG PRIME @base",
+    "from": "system",
+    "setting_id": "CXPCTG15",
+    "instantiation": "true",
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_long_retractions_when_cut": [
+        "nil"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil"
+    ],
+    "compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX PCTG PRIME @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX PCTG PRIME @base.json
@@ -1,0 +1,97 @@
+{
+    "type": "filament",
+    "name": "COEX PCTG PRIME @base",
+    "inherits": "fdm_filament_pctg",
+    "from": "system",
+    "filament_id": "CXPCTB15",
+    "instantiation": "false",
+    "filament_vendor": [
+        "COEX 3D"
+    ],
+    "filament_cost": [
+        "38.00"
+    ],
+    "filament_density": [
+        "1.27"
+    ],
+    "filament_type": [
+        "PCTG"
+    ],
+    "filament_notes": "High clarity and chemical resistance copolyester",
+    "nozzle_temperature": [
+        "275"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "275"
+    ],
+    "bed_temperature": [
+        "80"
+    ],
+    "bed_temperature_initial_layer": [
+        "85"
+    ],
+    "temperature_vitrification": [
+        "80"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_retraction_minimum_travel": [
+        "2"
+    ],
+    "filament_retract_before_wipe": [
+        "70%"
+    ],
+    "filament_retract_layer_change": [
+        "1"
+    ],
+    "filament_retract_when_changing_layer": [
+        "1"
+    ],
+    "filament_retraction_length": [
+        "3.5"
+    ],
+    "filament_retraction_speed": [
+        "35"
+    ],
+    "filament_deretraction_speed": [
+        "35"
+    ],
+    "filament_z_hop": [
+        "0.4"
+    ],
+    "filament_wipe": [
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "2"
+    ],
+    "fan_min_speed": [
+        "30"
+    ],
+    "fan_max_speed": [
+        "50"
+    ],
+    "disable_fan_first_layers": [
+        "2"
+    ],
+    "full_fan_speed_layer": [
+        "4"
+    ],
+    "slow_down_layer_time": [
+        "5"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "enable_pressure_advance": [
+        "1"
+    ],
+    "pressure_advance": [
+        "0.045"
+    ],
+    "compatible_printers": [],
+    "compatible_printers_condition": "",
+    "compatible_prints": [],
+    "compatible_prints_condition": ""
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX PETG @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX PETG @System.json
@@ -1,0 +1,18 @@
+{
+    "type": "filament",
+    "name": "COEX PETG @System",
+    "inherits": "COEX PETG @base",
+    "from": "system",
+    "setting_id": "CXPETG13",
+    "instantiation": "true",
+    "filament_max_volumetric_speed": [
+        "16"
+    ],
+    "filament_long_retractions_when_cut": [
+        "nil"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil"
+    ],
+    "compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX PETG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX PETG @base.json
@@ -1,0 +1,97 @@
+{
+    "type": "filament",
+    "name": "COEX PETG @base",
+    "inherits": "fdm_filament_pet",
+    "from": "system",
+    "filament_id": "CXPETB13",
+    "instantiation": "false",
+    "filament_vendor": [
+        "COEX 3D"
+    ],
+    "filament_cost": [
+        "33.00"
+    ],
+    "filament_density": [
+        "1.27"
+    ],
+    "filament_type": [
+        "PETG"
+    ],
+    "filament_notes": "IMPORTANT: Set travel speed to maximum your machine allows (200-500mm/s) to reduce stringing",
+    "nozzle_temperature": [
+        "245"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "250"
+    ],
+    "bed_temperature": [
+        "80"
+    ],
+    "bed_temperature_initial_layer": [
+        "85"
+    ],
+    "temperature_vitrification": [
+        "70"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_retraction_minimum_travel": [
+        "2"
+    ],
+    "filament_retract_before_wipe": [
+        "70%"
+    ],
+    "filament_retract_layer_change": [
+        "1"
+    ],
+    "filament_retract_when_changing_layer": [
+        "1"
+    ],
+    "filament_retraction_length": [
+        "4"
+    ],
+    "filament_retraction_speed": [
+        "30"
+    ],
+    "filament_deretraction_speed": [
+        "30"
+    ],
+    "filament_z_hop": [
+        "0.4"
+    ],
+    "filament_wipe": [
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "2"
+    ],
+    "fan_min_speed": [
+        "30"
+    ],
+    "fan_max_speed": [
+        "50"
+    ],
+    "disable_fan_first_layers": [
+        "2"
+    ],
+    "full_fan_speed_layer": [
+        "4"
+    ],
+    "slow_down_layer_time": [
+        "5"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "enable_pressure_advance": [
+        "1"
+    ],
+    "pressure_advance": [
+        "0.045"
+    ],
+    "compatible_printers": [],
+    "compatible_printers_condition": "",
+    "compatible_prints": [],
+    "compatible_prints_condition": ""
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX PLA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX PLA @System.json
@@ -1,0 +1,18 @@
+{
+    "type": "filament",
+    "name": "COEX PLA @System",
+    "inherits": "COEX PLA @base",
+    "from": "system",
+    "setting_id": "C0XPLA02",
+    "instantiation": "true",
+    "filament_max_volumetric_speed": [
+        "18"
+    ],
+    "filament_long_retractions_when_cut": [
+        "nil"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil"
+    ],
+    "compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX PLA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX PLA @base.json
@@ -1,0 +1,87 @@
+{
+    "type": "filament",
+    "name": "COEX PLA @base",
+    "inherits": "fdm_filament_pla",
+    "from": "system",
+    "filament_id": "CXPLAB02",
+    "instantiation": "false",
+    "filament_vendor": [
+        "COEX 3D"
+    ],
+    "filament_cost": [
+        "24.00"
+    ],
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_type": [
+        "PLA"
+    ],
+    "nozzle_temperature": [
+        "230"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "235"
+    ],
+    "bed_temperature": [
+        "60"
+    ],
+    "bed_temperature_initial_layer": [
+        "60"
+    ],
+    "temperature_vitrification": [
+        "55"
+    ],
+    "filament_max_volumetric_speed": [
+        "18"
+    ],
+    "filament_retraction_minimum_travel": [
+        "2"
+    ],
+    "filament_retract_before_wipe": [
+        "70%"
+    ],
+    "filament_retract_layer_change": [
+        "1"
+    ],
+    "filament_retract_when_changing_layer": [
+        "1"
+    ],
+    "filament_retraction_length": [
+        "1.5"
+    ],
+    "filament_retraction_speed": [
+        "45"
+    ],
+    "filament_deretraction_speed": [
+        "40"
+    ],
+    "filament_wipe": [
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "2"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "disable_fan_first_layers": [
+        "1"
+    ],
+    "full_fan_speed_layer": [
+        "3"
+    ],
+    "slow_down_layer_time": [
+        "5"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "compatible_printers": [],
+    "compatible_printers_condition": "",
+    "compatible_prints": [],
+    "compatible_prints_condition": ""
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX PLA PRIME @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX PLA PRIME @System.json
@@ -1,0 +1,18 @@
+{
+    "type": "filament",
+    "name": "COEX PLA PRIME @System",
+    "inherits": "COEX PLA PRIME @base",
+    "from": "system",
+    "setting_id": "C0XPLA08",
+    "instantiation": "true",
+    "filament_max_volumetric_speed": [
+        "15"
+    ],
+    "filament_long_retractions_when_cut": [
+        "nil"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil"
+    ],
+    "compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX PLA PRIME @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX PLA PRIME @base.json
@@ -1,0 +1,88 @@
+{
+    "type": "filament",
+    "name": "COEX PLA PRIME @base",
+    "inherits": "fdm_filament_pla",
+    "from": "system",
+    "filament_id": "CXPLAB08",
+    "instantiation": "false",
+    "filament_vendor": [
+        "COEX 3D"
+    ],
+    "filament_cost": [
+        "32.00"
+    ],
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_type": [
+        "PLA"
+    ],
+    "filament_notes": "Made with NatureWorks Ingeo 3D850 - improved heat resistance and toughness",
+    "nozzle_temperature": [
+        "235"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "240"
+    ],
+    "bed_temperature": [
+        "60"
+    ],
+    "bed_temperature_initial_layer": [
+        "60"
+    ],
+    "temperature_vitrification": [
+        "60"
+    ],
+    "filament_max_volumetric_speed": [
+        "15"
+    ],
+    "filament_retraction_minimum_travel": [
+        "2"
+    ],
+    "filament_retract_before_wipe": [
+        "70%"
+    ],
+    "filament_retract_layer_change": [
+        "1"
+    ],
+    "filament_retract_when_changing_layer": [
+        "1"
+    ],
+    "filament_retraction_length": [
+        "1.2"
+    ],
+    "filament_retraction_speed": [
+        "50"
+    ],
+    "filament_deretraction_speed": [
+        "40"
+    ],
+    "filament_wipe": [
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "2"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "disable_fan_first_layers": [
+        "1"
+    ],
+    "full_fan_speed_layer": [
+        "3"
+    ],
+    "slow_down_layer_time": [
+        "5"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "compatible_printers": [],
+    "compatible_printers_condition": "",
+    "compatible_prints": [],
+    "compatible_prints_condition": ""
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX PLA+Silk @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX PLA+Silk @System.json
@@ -1,0 +1,18 @@
+{
+    "type": "filament",
+    "name": "COEX PLA+Silk @System",
+    "inherits": "COEX PLA+Silk @base",
+    "from": "system",
+    "setting_id": "C0XPLS03",
+    "instantiation": "true",
+    "filament_max_volumetric_speed": [
+        "15"
+    ],
+    "filament_long_retractions_when_cut": [
+        "nil"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil"
+    ],
+    "compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX PLA+Silk @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX PLA+Silk @base.json
@@ -1,0 +1,91 @@
+{
+    "type": "filament",
+    "name": "COEX PLA+Silk @base",
+    "inherits": "fdm_filament_pla_silk",
+    "from": "system",
+    "filament_id": "CXPLSB03",
+    "instantiation": "false",
+    "filament_vendor": [
+        "COEX 3D"
+    ],
+    "filament_cost": [
+        "30.00"
+    ],
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_type": [
+        "PLA"
+    ],
+    "filament_notes": "Silk finish for aesthetic prints - slightly higher temperature than regular PLA",
+    "nozzle_temperature": [
+        "240"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "245"
+    ],
+    "bed_temperature": [
+        "60"
+    ],
+    "bed_temperature_initial_layer": [
+        "60"
+    ],
+    "temperature_vitrification": [
+        "55"
+    ],
+    "filament_max_volumetric_speed": [
+        "15"
+    ],
+    "filament_retraction_minimum_travel": [
+        "2"
+    ],
+    "filament_retract_before_wipe": [
+        "70%"
+    ],
+    "filament_retract_layer_change": [
+        "1"
+    ],
+    "filament_retract_when_changing_layer": [
+        "1"
+    ],
+    "filament_retraction_length": [
+        "1.5"
+    ],
+    "filament_retraction_speed": [
+        "45"
+    ],
+    "filament_deretraction_speed": [
+        "40"
+    ],
+    "filament_wipe": [
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "2"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "disable_fan_first_layers": [
+        "1"
+    ],
+    "full_fan_speed_layer": [
+        "3"
+    ],
+    "slow_down_layer_time": [
+        "5"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "external_perimeter_speed": [
+        "50%"
+    ],
+    "compatible_printers": [],
+    "compatible_printers_condition": "",
+    "compatible_prints": [],
+    "compatible_prints_condition": ""
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX TPE 30D @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX TPE 30D @System.json
@@ -1,0 +1,12 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 30D @System",
+    "inherits": "COEX TPE 30D @base",
+    "from": "system",
+    "setting_id": "C0X30D20",
+    "instantiation": "true",
+    "filament_max_volumetric_speed": [
+        "3.5"
+    ],
+    "compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX TPE 30D @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX TPE 30D @base.json
@@ -1,0 +1,109 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 30D @base",
+    "inherits": "fdm_filament_tpu",
+    "from": "system",
+    "filament_id": "CX30DB20",
+    "instantiation": "false",
+    "filament_vendor": [
+        "COEX 3D"
+    ],
+    "filament_cost": [
+        "80.00"
+    ],
+    "filament_density": [
+        "1.15"
+    ],
+    "filament_type": [
+        "TPU"
+    ],
+    "filament_notes": "Flexible filament - print slowly with minimal retraction",
+    "nozzle_temperature": [
+        "240"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "240"
+    ],
+    "bed_temperature": [
+        "30"
+    ],
+    "bed_temperature_initial_layer": [
+        "35"
+    ],
+    "temperature_vitrification": [
+        "60"
+    ],
+    "filament_max_volumetric_speed": [
+        "3.5"
+    ],
+    "filament_retraction_minimum_travel": [
+        "3"
+    ],
+    "filament_retract_before_wipe": [
+        "0%"
+    ],
+    "filament_retract_layer_change": [
+        "0"
+    ],
+    "filament_retract_when_changing_layer": [
+        "0"
+    ],
+    "filament_retraction_length": [
+        "0.4"
+    ],
+    "filament_retraction_speed": [
+        "20"
+    ],
+    "filament_deretraction_speed": [
+        "20"
+    ],
+    "filament_wipe": [
+        "0"
+    ],
+    "filament_wipe_distance": [
+        "0"
+    ],
+    "fan_min_speed": [
+        "80"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "disable_fan_first_layers": [
+        "1"
+    ],
+    "full_fan_speed_layer": [
+        "2"
+    ],
+    "slow_down_layer_time": [
+        "10"
+    ],
+    "slow_down_min_speed": [
+        "5"
+    ],
+    "initial_layer_print_speed": [
+        "15"
+    ],
+    "outer_wall_speed": [
+        "25"
+    ],
+    "inner_wall_speed": [
+        "30"
+    ],
+    "infill_speed": [
+        "30"
+    ],
+    "top_surface_speed": [
+        "25"
+    ],
+    "travel_speed": [
+        "150"
+    ],
+    "enable_pressure_advance": [
+        "0"
+    ],
+    "compatible_printers": [],
+    "compatible_printers_condition": "",
+    "compatible_prints": [],
+    "compatible_prints_condition": ""
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX TPE 40D @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX TPE 40D @System.json
@@ -1,0 +1,18 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 40D @System",
+    "inherits": "COEX TPE 40D @base",
+    "from": "system",
+    "setting_id": "C0X40D18",
+    "instantiation": "true",
+    "filament_max_volumetric_speed": [
+        "5.5"
+    ],
+    "filament_long_retractions_when_cut": [
+        "nil"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil"
+    ],
+    "compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX TPE 40D @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX TPE 40D @base.json
@@ -1,0 +1,109 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 40D @base",
+    "inherits": "fdm_filament_tpu",
+    "from": "system",
+    "filament_id": "CX40DB20",
+    "instantiation": "false",
+    "filament_vendor": [
+        "COEX 3D"
+    ],
+    "filament_cost": [
+        "80.00"
+    ],
+    "filament_density": [
+        "1.18"
+    ],
+    "filament_type": [
+        "TPU"
+    ],
+    "filament_notes": "Flexible filament - print slowly with minimal retraction",
+    "nozzle_temperature": [
+        "240"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "240"
+    ],
+    "bed_temperature": [
+        "30"
+    ],
+    "bed_temperature_initial_layer": [
+        "35"
+    ],
+    "temperature_vitrification": [
+        "60"
+    ],
+    "filament_max_volumetric_speed": [
+        "5.5"
+    ],
+    "filament_retraction_minimum_travel": [
+        "3"
+    ],
+    "filament_retract_before_wipe": [
+        "0%"
+    ],
+    "filament_retract_layer_change": [
+        "0"
+    ],
+    "filament_retract_when_changing_layer": [
+        "0"
+    ],
+    "filament_retraction_length": [
+        "0.4"
+    ],
+    "filament_retraction_speed": [
+        "20"
+    ],
+    "filament_deretraction_speed": [
+        "20"
+    ],
+    "filament_wipe": [
+        "0"
+    ],
+    "filament_wipe_distance": [
+        "0"
+    ],
+    "fan_min_speed": [
+        "80"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "disable_fan_first_layers": [
+        "1"
+    ],
+    "full_fan_speed_layer": [
+        "2"
+    ],
+    "slow_down_layer_time": [
+        "10"
+    ],
+    "slow_down_min_speed": [
+        "5"
+    ],
+    "initial_layer_print_speed": [
+        "15"
+    ],
+    "outer_wall_speed": [
+        "25"
+    ],
+    "inner_wall_speed": [
+        "30"
+    ],
+    "infill_speed": [
+        "30"
+    ],
+    "top_surface_speed": [
+        "25"
+    ],
+    "travel_speed": [
+        "150"
+    ],
+    "enable_pressure_advance": [
+        "0"
+    ],
+    "compatible_printers": [],
+    "compatible_printers_condition": "",
+    "compatible_prints": [],
+    "compatible_prints_condition": ""
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX TPE 60D @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX TPE 60D @System.json
@@ -1,0 +1,18 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 60D @System",
+    "inherits": "COEX TPE 60D @base",
+    "from": "system",
+    "setting_id": "C0X60D19",
+    "instantiation": "true",
+    "filament_max_volumetric_speed": [
+        "6.5"
+    ],
+    "filament_long_retractions_when_cut": [
+        "nil"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil"
+    ],
+    "compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX TPE 60D @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX TPE 60D @base.json
@@ -1,0 +1,109 @@
+{
+    "type": "filament",
+    "name": "COEX TPE 60D @base",
+    "inherits": "fdm_filament_tpu",
+    "from": "system",
+    "filament_id": "CX60DB19",
+    "instantiation": "false",
+    "filament_vendor": [
+        "COEX 3D"
+    ],
+    "filament_cost": [
+        "80.00"
+    ],
+    "filament_density": [
+        "1.20"
+    ],
+    "filament_type": [
+        "TPU"
+    ],
+    "filament_notes": "Flexible filament - print slowly with minimal retraction",
+    "nozzle_temperature": [
+        "240"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "240"
+    ],
+    "bed_temperature": [
+        "30"
+    ],
+    "bed_temperature_initial_layer": [
+        "35"
+    ],
+    "temperature_vitrification": [
+        "60"
+    ],
+    "filament_max_volumetric_speed": [
+        "6.5"
+    ],
+    "filament_retraction_minimum_travel": [
+        "3"
+    ],
+    "filament_retract_before_wipe": [
+        "0%"
+    ],
+    "filament_retract_layer_change": [
+        "0"
+    ],
+    "filament_retract_when_changing_layer": [
+        "0"
+    ],
+    "filament_retraction_length": [
+        "0.4"
+    ],
+    "filament_retraction_speed": [
+        "20"
+    ],
+    "filament_deretraction_speed": [
+        "20"
+    ],
+    "filament_wipe": [
+        "0"
+    ],
+    "filament_wipe_distance": [
+        "0"
+    ],
+    "fan_min_speed": [
+        "80"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "disable_fan_first_layers": [
+        "1"
+    ],
+    "full_fan_speed_layer": [
+        "2"
+    ],
+    "slow_down_layer_time": [
+        "10"
+    ],
+    "slow_down_min_speed": [
+        "5"
+    ],
+    "initial_layer_print_speed": [
+        "15"
+    ],
+    "outer_wall_speed": [
+        "25"
+    ],
+    "inner_wall_speed": [
+        "30"
+    ],
+    "infill_speed": [
+        "30"
+    ],
+    "top_surface_speed": [
+        "25"
+    ],
+    "travel_speed": [
+        "150"
+    ],
+    "enable_pressure_advance": [
+        "0"
+    ],
+    "compatible_printers": [],
+    "compatible_printers_condition": "",
+    "compatible_prints": [],
+    "compatible_prints_condition": ""
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX TPU 60A @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX TPU 60A @System.json
@@ -1,0 +1,18 @@
+{
+    "type": "filament",
+    "name": "COEX TPU 60A @System",
+    "inherits": "COEX TPU 60A @base",
+    "from": "system",
+    "setting_id": "C0X60A17",
+    "instantiation": "true",
+    "filament_max_volumetric_speed": [
+        "1"
+    ],
+    "filament_long_retractions_when_cut": [
+        "nil"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil"
+    ],
+    "compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX TPU 60A @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/COEX/COEX TPU 60A @base.json
@@ -1,0 +1,109 @@
+{
+    "type": "filament",
+    "name": "COEX TPU 60A @base",
+    "inherits": "fdm_filament_tpu",
+    "from": "system",
+    "filament_id": "CX60AB17",
+    "instantiation": "false",
+    "filament_vendor": [
+        "COEX 3D"
+    ],
+    "filament_cost": [
+        "95.00"
+    ],
+    "filament_density": [
+        "1.14"
+    ],
+    "filament_type": [
+        "TPU"
+    ],
+    "filament_notes": "Flexible filament - print slowly with minimal retraction",
+    "nozzle_temperature": [
+        "225"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "225"
+    ],
+    "bed_temperature": [
+        "0"
+    ],
+    "bed_temperature_initial_layer": [
+        "0"
+    ],
+    "temperature_vitrification": [
+        "60"
+    ],
+    "filament_max_volumetric_speed": [
+        "1"
+    ],
+    "filament_retraction_minimum_travel": [
+        "3"
+    ],
+    "filament_retract_before_wipe": [
+        "0%"
+    ],
+    "filament_retract_layer_change": [
+        "0"
+    ],
+    "filament_retract_when_changing_layer": [
+        "0"
+    ],
+    "filament_retraction_length": [
+        "0"
+    ],
+    "filament_retraction_speed": [
+        "20"
+    ],
+    "filament_deretraction_speed": [
+        "20"
+    ],
+    "filament_wipe": [
+        "0"
+    ],
+    "filament_wipe_distance": [
+        "0"
+    ],
+    "fan_min_speed": [
+        "80"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "disable_fan_first_layers": [
+        "1"
+    ],
+    "full_fan_speed_layer": [
+        "2"
+    ],
+    "slow_down_layer_time": [
+        "10"
+    ],
+    "slow_down_min_speed": [
+        "5"
+    ],
+    "initial_layer_print_speed": [
+        "15"
+    ],
+    "outer_wall_speed": [
+        "25"
+    ],
+    "inner_wall_speed": [
+        "30"
+    ],
+    "infill_speed": [
+        "30"
+    ],
+    "top_surface_speed": [
+        "25"
+    ],
+    "travel_speed": [
+        "150"
+    ],
+    "enable_pressure_advance": [
+        "0"
+    ],
+    "compatible_printers": [],
+    "compatible_printers_condition": "",
+    "compatible_prints": [],
+    "compatible_prints_condition": ""
+}


### PR DESCRIPTION
* Fix some errors (e.g., missing instantiation, missing commas, wrong order) and remove unnecessary parameters.

* Fix filament profiles to use arrays for vendor, cost, density, type, temperature, and speed attributes across COEX materials.