### PR TITLE
Feature: Retract amount after wipe

### DIFF
--- a/src/libslic3r/Extruder.cpp
+++ b/src/libslic3r/Extruder.cpp
@@ -168,7 +168,13 @@ double Extruder::filament_flow_ratio() const
 // Return a "retract_before_wipe" percentage as a factor clamped to <0, 1>
 double Extruder::retract_before_wipe() const
 {
-    return std::min(1., std::max(0., m_config->retract_before_wipe.get_at(m_id) * 0.01));
+    return std::clamp(m_config->retract_before_wipe.get_at(m_id) * 0.01, 0., 1.);
+}
+
+// Return a "retract_after_wipe" percentage as a factor clamped to <0, 1>
+double Extruder::retract_after_wipe() const
+{
+    return std::min(std::clamp(m_config->retract_after_wipe.get_at(m_id) * 0.01, 0., 1.), 1. - retract_before_wipe());
 }
 
 double Extruder::retraction_length() const

--- a/src/libslic3r/Extruder.hpp
+++ b/src/libslic3r/Extruder.hpp
@@ -63,6 +63,7 @@ public:
     double filament_cost() const;
     double filament_flow_ratio() const;
     double retract_before_wipe() const;
+    double retract_after_wipe() const;
     double retraction_length() const;
     double retract_lift() const;
     int    retract_speed() const;

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -306,46 +306,61 @@ static std::vector<Vec2d> get_path_of_change_filament(const Print& print)
         
         // Declare & initialize retraction lengths
         double retraction_length_remaining = 0,
-                retractionBeforeWipe = 0,
-                retractionDuringWipe = 0;
+            retraction_length_before_wipe = 0,
+            retraction_length_during_wipe = 0,
+            retraction_length_after_wipe = 0;
         
-        // initialise the remaining retraction amount with the full retraction amount.
-        retraction_length_remaining = toolchange ? extruder->retract_length_toolchange() : extruder->retraction_length();
+        // Initialise the remaining retraction amount with the full retraction amount.
+        retraction_length_remaining = toolchange ? 
+            extruder->retract_length_toolchange() : extruder->retraction_length();
         
-        // nothing to retract - return early
-        if(retraction_length_remaining <=EPSILON) return {0.f,0.f};
+        // Nothing to retract - return early
+        if (retraction_length_remaining <= EPSILON)
+            return { 0.f, 0.f, 0.f };
         
-        // calculate retraction before wipe distance from the user setting. Keep adding to this variable any excess retraction needed
-        // to be performed before the wipe.
-        retractionBeforeWipe = retraction_length_remaining * extruder->retract_before_wipe();
-        retraction_length_remaining -= retractionBeforeWipe; // subtract it from the remaining retraction length
-        
-        // all of the retraction is to be done before the wipe
-        if(retraction_length_remaining <=EPSILON) return {retractionBeforeWipe,0.f};
+        // Calculate retraction before and after wipe distances from the user setting. 
+        // Keep adding to the for retraction before wipe variable any excess retraction 
+        // needed to be performed before the wipe.
+        retraction_length_before_wipe = retraction_length_remaining * extruder->retract_before_wipe();
+        retraction_length_after_wipe = retraction_length_remaining * extruder->retract_after_wipe();
+
+        // Subtract it from the remaining retraction length
+        retraction_length_remaining -= retraction_length_before_wipe + retraction_length_after_wipe;
+
+        // All of the retraction is to be done before the wipe
+        if (retraction_length_remaining <= EPSILON) 
+            return { retraction_length_before_wipe, 0., retraction_length_after_wipe };
         
         // Calculate wipe speed
-        double wipe_speed = config.role_based_wipe_speed ? writer.get_current_speed() / 60.0 : config.get_abs_value("wipe_speed");
+        double wipe_speed = config.role_based_wipe_speed ? 
+            writer.get_current_speed() / 60.0 : config.get_abs_value("wipe_speed");
         wipe_speed = std::max(wipe_speed, 10.0);
 
         // Process wipe path & calculate wipe path length
         double wipe_dist = scale_(config.wipe_distance.get_at(extruder_id));
-        Polyline wipe_path = {last_pos};
+        Polyline wipe_path = { last_pos };
         wipe_path.append(this->path.points.begin() + 1, this->path.points.end());
         double wipe_path_length = std::min(wipe_path.length(), wipe_dist);
 
         // Calculate the maximum retraction amount during wipe
-        retractionDuringWipe = config.retraction_speed.get_at(extruder_id) * unscale_(wipe_path_length) / wipe_speed;
-        // If the maximum retraction amount during wipe is too small, return 0 and retract everything prior to the wipe.
-        if(retractionDuringWipe <= EPSILON) return {retractionBeforeWipe,0.f};
+        retraction_length_during_wipe = config.retraction_speed.get_at(extruder_id) * 
+            unscale_(wipe_path_length) / wipe_speed;
+
+        // If the maximum retraction amount during wipe is too small, 
+        // return 0 and retract everything prior to the wipe.
+        if (retraction_length_during_wipe <= EPSILON) 
+            return { retraction_length_before_wipe, 0., retraction_length_after_wipe };
         
         // If the maximum retraction amount during wipe is greater than any remaining retraction length
         // return the remaining retraction length to be retracted during the wipe
-        if (retractionDuringWipe - retraction_length_remaining > EPSILON) return {retractionBeforeWipe,retraction_length_remaining};
+        if (retraction_length_during_wipe - retraction_length_remaining > EPSILON) 
+            return { retraction_length_before_wipe, retraction_length_remaining, retraction_length_after_wipe };
         
         // We will always proceed with incrementing the retraction amount before wiping with the difference
         // and return the maximum allowed wipe amount to be retracted during the wipe move
-        retractionBeforeWipe += retraction_length_remaining - retractionDuringWipe;
-        return {retractionBeforeWipe, retractionDuringWipe};
+        retraction_length_before_wipe += retraction_length_remaining - retraction_length_during_wipe;
+
+        return { retraction_length_before_wipe, retraction_length_during_wipe, retraction_length_after_wipe };
     }
 
     std::string transform_gcode(const std::string &gcode, Vec2f pos, const Vec2f &translation, float angle)
@@ -7024,8 +7039,9 @@ std::string GCode::retract(bool toolchange, bool is_last_retraction, LiftType li
     // wipe (if it's enabled for this extruder and we have a stored wipe path and no-zero wipe distance)
     if (FILAMENT_CONFIG(wipe) && m_wipe.has_path() && scale_(FILAMENT_CONFIG(wipe_distance)) > SCALED_EPSILON) {
         Wipe::RetractionValues wipeRetractions = m_wipe.calculateWipeRetractionLengths(*this, toolchange);
-        gcode += toolchange ? m_writer.retract_for_toolchange(true,wipeRetractions.retractLengthBeforeWipe) : m_writer.retract(true, wipeRetractions.retractLengthBeforeWipe);
-        gcode += m_wipe.wipe(*this,wipeRetractions.retractLengthDuringWipe, toolchange, is_last_retraction);
+        gcode += toolchange ? m_writer.retract_for_toolchange(true, wipeRetractions.retraction_length_before_wipe) :
+                              m_writer.retract(true, wipeRetractions.retraction_length_before_wipe);
+        gcode += m_wipe.wipe(*this, wipeRetractions.retraction_length_during_wipe, toolchange, is_last_retraction);
     }
 
     /*  The parent class will decide whether we need to perform an actual retraction

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -60,9 +60,11 @@ class Wipe {
 public:
     bool enable;
     Polyline path;
+
     struct RetractionValues{
-        double retractLengthBeforeWipe;
-        double retractLengthDuringWipe;
+        double retraction_length_before_wipe = 0.;
+        double retraction_length_during_wipe = 0.;
+        double retraction_length_after_wipe  = 0.;
     };
 
     Wipe() : enable(false) {}

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -964,7 +964,7 @@ static std::vector<std::string> s_Preset_filament_options {/*"filament_colour", 
     "activate_air_filtration","during_print_exhaust_fan_speed","complete_print_exhaust_fan_speed",
     // Retract overrides
     "filament_retraction_length", "filament_z_hop", "filament_z_hop_types", "filament_retract_lift_above", "filament_retract_lift_below", "filament_retract_lift_enforce", "filament_retraction_speed", "filament_deretraction_speed", "filament_retract_restart_extra", "filament_retraction_minimum_travel",
-    "filament_retract_when_changing_layer", "filament_wipe", "filament_retract_before_wipe",
+    "filament_retract_when_changing_layer", "filament_wipe", "filament_retract_before_wipe", "filament_retract_after_wipe",
     // Profile compatibility
     "filament_vendor", "compatible_prints", "compatible_prints_condition", "compatible_printers", "compatible_printers_condition", "inherits",
     //BBS

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -172,6 +172,7 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
         "filename_format",
         "retraction_minimum_travel",
         "retract_before_wipe",
+        "retract_after_wipe",
         "retract_when_changing_layer",
         "retraction_length",
         "retract_length_toolchange",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -77,6 +77,9 @@ const std::vector<std::string> filament_extruder_override_keys = {
     "filament_wipe",
     // percents
     "filament_retract_before_wipe",
+    // Orca
+    "filament_retract_after_wipe",
+    // BBS
     "filament_long_retractions_when_cut",
     "filament_retraction_distances_when_cut"
 };
@@ -4576,6 +4579,14 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionPercents { 100 });
 
+    def = this->add("retract_after_wipe", coPercents);
+    def->label = L("Retract amount after wipe");
+    def->tooltip = L("The length of fast retraction after wipe, relative to retraction length. "
+                     "The value will be clamped by 100% minus the retract amount before the wipe value.");
+    def->sidetext = "%";
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionPercents { 0 });
+
     def = this->add("retract_when_changing_layer", coBools);
     def->label = L("Retract when change layer");
     def->tooltip = L("Force a retraction when changes layer.");
@@ -6579,7 +6590,7 @@ void PrintConfigDef::init_extruder_option_keys()
     m_extruder_option_keys = {
         "extruder_type", "nozzle_diameter", "default_nozzle_volume_type", "min_layer_height", "max_layer_height", "extruder_offset",
         "retraction_length", "z_hop", "z_hop_types", "travel_slope", "retract_lift_above", "retract_lift_below", "retract_lift_enforce", "retraction_speed", "deretraction_speed",
-        "retract_before_wipe", "retract_restart_extra", "retraction_minimum_travel", "wipe", "wipe_distance",
+        "retract_before_wipe", "retract_after_wipe", "retract_restart_extra", "retraction_minimum_travel", "wipe", "wipe_distance",
         "retract_when_changing_layer", "retract_length_toolchange", "retract_restart_extra_toolchange", "extruder_colour",
         "default_filament_profile","retraction_distances_when_cut","long_retractions_when_cut"
     };
@@ -6587,6 +6598,7 @@ void PrintConfigDef::init_extruder_option_keys()
     m_extruder_retract_keys = {
         "deretraction_speed",
         "long_retractions_when_cut",
+        "retract_after_wipe",
         "retract_before_wipe",
         "retract_lift_above",
         "retract_lift_below",
@@ -6611,7 +6623,7 @@ void PrintConfigDef::init_filament_option_keys()
     m_filament_option_keys = {
         "filament_diameter", "min_layer_height", "max_layer_height","volumetric_speed_coefficients",
         "retraction_length", "z_hop", "z_hop_types", "retract_lift_above", "retract_lift_below", "retract_lift_enforce", "retraction_speed", "deretraction_speed",
-        "retract_before_wipe", "retract_restart_extra", "retraction_minimum_travel", "wipe", "wipe_distance",
+        "retract_before_wipe", "retract_after_wipe", "retract_restart_extra", "retraction_minimum_travel", "wipe", "wipe_distance",
         "retract_when_changing_layer", "retract_length_toolchange", "retract_restart_extra_toolchange", "filament_colour",
         "default_filament_profile","retraction_distances_when_cut","long_retractions_when_cut"/*,"filament_seam_gap"*/
     };
@@ -6620,6 +6632,7 @@ void PrintConfigDef::init_filament_option_keys()
         "deretraction_speed",
         "long_retractions_when_cut",
         "retract_before_wipe",
+        "retract_after_wipe",
         "retract_lift_above",
         "retract_lift_below",
         "retract_lift_enforce",
@@ -7598,6 +7611,9 @@ std::set<std::string> filament_options_with_variant = {
     //BBS
     "filament_wipe_distance",
     "filament_retract_before_wipe",
+    // Orca
+    "filament_retract_after_wipe",
+    //BBS
     "filament_long_retractions_when_cut",
     "filament_retraction_distances_when_cut",
     "long_retractions_when_ec",

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1284,6 +1284,9 @@ PRINT_CONFIG_CLASS_DEFINE(
 
     
     ((ConfigOptionPercents,            retract_before_wipe))
+    // Orca
+    ((ConfigOptionPercents,            retract_after_wipe))
+
     ((ConfigOptionFloats,              retraction_length))
     ((ConfigOptionFloats,              retract_length_toolchange))
     ((ConfigOptionInt,                 enable_long_retraction_when_cut))

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -3601,6 +3601,9 @@ void TabFilament::add_filament_overrides_page()
                                         //BBS
                                         "filament_wipe_distance",
                                         "filament_retract_before_wipe",
+                                        // Orca
+                                        "filament_retract_after_wipe",
+                                        // BBS
                                         "filament_long_retractions_when_cut",
                                         "filament_retraction_distances_when_cut"
                                         //SoftFever
@@ -3640,6 +3643,9 @@ void TabFilament::update_filament_overrides_page(const DynamicPrintConfig* print
                                             //BBS
                                             "filament_wipe_distance",
                                             "filament_retract_before_wipe",
+                                            // Orca
+                                            "filament_retract_after_wipe",
+                                            // BBS
                                             "filament_long_retractions_when_cut",
                                             "filament_retraction_distances_when_cut"
                                             //SoftFever
@@ -3677,6 +3683,16 @@ void TabFilament::update_filament_overrides_page(const DynamicPrintConfig* print
             bool filament_enabled = m_config->option<ConfigOptionBools>("filament_long_retractions_when_cut")->values[extruder_idx] == 1;
             toggle_line(opt_key, filament_enabled && machine_enabled, extruder_idx + 256);
             field->toggle(is_checked && filament_enabled && machine_enabled);
+        } else if (opt_key == "filament_retract_before_wipe" || opt_key == "filament_retract_after_wipe") {
+            bool wipe = (have_retract_length || printers_config->opt_bool("use_firmware_retraction")) && m_config->opt_bool("filament_wipe", extruder_idx);
+
+            double value_to_compare = 0.;
+            if (opt_key == "filament_retract_before_wipe")
+                value_to_compare = m_config->option<ConfigOptionPercents>("filament_retract_after_wipe")->get_at(extruder_idx);
+            else if (opt_key == "filament_retract_after_wipe")
+                value_to_compare = m_config->option<ConfigOptionPercents>("filament_retract_before_wipe")->get_at(extruder_idx);
+
+            toggle_option(opt_key, wipe && !is_approx(std::clamp(value_to_compare, 0., 100.), 100.), extruder_idx);
         } else {
             if (!is_checked) {
                 const std::string printer_opt_key = opt_key.substr(strlen("filament_"));
@@ -4154,6 +4170,41 @@ void TabFilament::clear_pages()
 
     //BBS: GUI refactor
     m_overrides_options.clear();
+}
+
+void TabFilament::on_value_change(const std::string& opt_key, const boost::any& value)
+{
+    if (wxGetApp().plater() == nullptr || m_config_manipulation.is_applying())
+        return;
+
+    if (opt_key == "filament_retract_after_wipe" || opt_key == "filament_retract_before_wipe") {
+        const int extruder_idx = 0; // #ys_FIXME
+        auto percent_value_clamp = [](double percent_value) { return std::clamp(percent_value, 0., 100.); };
+        double dvalue = boost::any_cast<double>(value);
+
+        double retract_before_wipe = percent_value_clamp(opt_key == "filament_retract_before_wipe" 
+            ? dvalue : m_config->option<ConfigOptionPercents>("filament_retract_before_wipe")->get_at(extruder_idx));
+
+        double retract_after_wipe = percent_value_clamp(opt_key == "filament_retract_after_wipe" 
+            ? dvalue : m_config->option<ConfigOptionPercents>("filament_retract_after_wipe")->get_at(extruder_idx));
+
+        bool need_to_reload_config = false;
+
+        if (percent_value_clamp(dvalue) != dvalue) {
+            change_opt_value(*m_config, opt_key, percent_value_clamp(dvalue), extruder_idx);
+            need_to_reload_config = true;
+        }
+
+        if (retract_after_wipe > 100. - retract_before_wipe) {
+            change_opt_value(*m_config, "filament_retract_after_wipe", 100. - retract_before_wipe, extruder_idx);
+            need_to_reload_config = true;
+        }
+
+        if (need_to_reload_config)
+            reload_config();
+    }
+
+    Tab::on_value_change(opt_key, value);
 }
 
 wxSizer* Tab::description_line_widget(wxWindow* parent, ogStaticText* *StaticText, wxString text /*= wxEmptyString*/)
@@ -4845,6 +4896,8 @@ if (is_marlin_flavor)
             optgroup->append_single_option_line("wipe", "", extruder_idx);
             optgroup->append_single_option_line("wipe_distance", "", extruder_idx);
             optgroup->append_single_option_line("retract_before_wipe", "", extruder_idx);
+            // Orca
+            optgroup->append_single_option_line("retract_after_wipe", "", extruder_idx);
 
             optgroup = page->new_optgroup(L("Z-Hop"), L"param_extruder_lift_enforcement");
             optgroup->append_single_option_line("retract_lift_enforce", "", extruder_idx);
@@ -5132,15 +5185,21 @@ void TabPrinter::toggle_options()
 
         // some options only apply when not using firmware retraction
         vec.resize(0);
-        vec = {"retraction_speed", "deretraction_speed",    "retract_before_wipe",
-               "retract_length",   "retract_restart_extra", "wipe",
-               "wipe_distance"};
+        vec = {"retraction_speed", "deretraction_speed", "retract_before_wipe", "retract_after_wipe",
+               "retract_length", "retract_restart_extra", "wipe", "wipe_distance"};
         for (auto el : vec)
             //BBS
             toggle_option(el, retraction && !use_firmware_retraction, i);
 
         bool wipe = retraction && m_config->opt_bool("wipe", i);
-        toggle_option("retract_before_wipe", wipe, i);
+
+        // Orca
+        double retract_before_wipe = m_config->option<ConfigOptionPercents>("retract_before_wipe")->get_at(i);
+        double retract_after_wipe  = m_config->option<ConfigOptionPercents>("retract_after_wipe")->get_at(i);
+
+        toggle_option("retract_before_wipe", wipe && !is_approx(retract_after_wipe, 100.), i);
+        toggle_option("retract_after_wipe", wipe && !is_approx(retract_before_wipe, 100.), i);
+
         if (use_firmware_retraction && wipe) {
             //wxMessageDialog dialog(parent(),
             MessageDialog dialog(parent(),
@@ -5207,6 +5266,52 @@ void TabPrinter::toggle_options()
         toggle_option("min_resonance_avoidance_speed", resonance_avoidance);
         toggle_option("max_resonance_avoidance_speed", resonance_avoidance);
     }
+}
+
+void TabPrinter::on_value_change(const std::string& opt_key, const boost::any& value)
+{
+    if (wxGetApp().plater() == nullptr || m_config_manipulation.is_applying())
+        return;
+
+    const int pos = opt_key.find("#");
+
+    if (pos > 0) {
+        std::string temp_str = opt_key;
+        boost::erase_head(temp_str, pos + 1);
+        int orig_opt_idx = static_cast<size_t>(atoi(temp_str.c_str()));
+        int opt_idx = orig_opt_idx >= 0 ? orig_opt_idx : 0;
+
+        std::string opt_key_pure = opt_key;
+        boost::erase_tail(opt_key_pure, opt_key_pure.size() - pos);
+
+        if (opt_key_pure == "retract_after_wipe" || opt_key_pure == "retract_before_wipe") {
+            auto percent_value_clamp = [](double percent_value) { return std::clamp(percent_value, 0., 100.); };
+            double dvalue = boost::any_cast<double>(value);
+
+            double retract_before_wipe = percent_value_clamp(opt_key_pure == "retract_before_wipe" 
+                ? dvalue : m_config->option<ConfigOptionPercents>("retract_before_wipe")->get_at(opt_idx));
+
+            double retract_after_wipe = percent_value_clamp(opt_key_pure == "retract_after_wipe" 
+                ? dvalue : m_config->option<ConfigOptionPercents>("retract_after_wipe")->get_at(opt_idx));
+
+            bool need_to_reload_config = false;
+
+            if (percent_value_clamp(dvalue) != dvalue) {
+                change_opt_value(*m_config, opt_key_pure, percent_value_clamp(dvalue), opt_idx);
+                need_to_reload_config = true;
+            }
+
+            if (retract_after_wipe > 100. - retract_before_wipe) {
+                change_opt_value(*m_config, "retract_after_wipe", 100. - retract_before_wipe, opt_idx);
+                need_to_reload_config = true;
+            }
+
+            if (need_to_reload_config)
+                reload_config();
+        }
+    }
+
+    Tab::on_value_change(opt_key, value);
 }
 
 void TabPrinter::update()

--- a/src/slic3r/GUI/Tab.hpp
+++ b/src/slic3r/GUI/Tab.hpp
@@ -584,6 +584,8 @@ public:
     void        clear_pages() override;
 	bool 		supports_printer_technology(const PrinterTechnology tech) const override { return tech == ptFFF; }
 
+	void		on_value_change(const std::string& opt_key, const boost::any& value) override;
+
     const std::string&	get_custom_gcode(const t_config_option_key& opt_key) override;
     void				set_custom_gcode(const t_config_option_key& opt_key, const std::string& value) override;
 };
@@ -640,11 +642,11 @@ public:
 	bool 		supports_printer_technology(const PrinterTechnology /* tech */) const override { return true; }
 
 	void		set_extruder_volume_type(int extruder_id, NozzleVolumeType type);
+	void		on_value_change(const std::string& opt_key, const boost::any& value) override;
 
 	wxSizer*	create_bed_shape_widget(wxWindow* parent);
 	void		cache_extruder_cnt(const DynamicPrintConfig* config = nullptr);
 	bool		apply_extruder_cnt_from_cache();
-
 };
 
 class TabSLAMaterial : public Tab


### PR DESCRIPTION
A new setting added - `Retract amount after wipe`. It controls the length of fast retraction after wipe, relative to retraction length. The value will be clamped by 100% minus the retract amount before the wipe value.

# Description

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
