### PR TITLE
Hyperlink class (#9947)

### DIFF
--- a/.doxygen
+++ b/.doxygen
@@ -1565,7 +1565,7 @@ TOC_EXPAND             = NO
 # protocol see https://www.sitemaps.org
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-SITEMAP_URL            =
+SITEMAP_URL            = internals.orcaslicer.com
 
 # If the GENERATE_QHP tag is set to YES and both QHP_NAMESPACE and
 # QHP_VIRTUAL_FOLDER are set, an additional index file will be generated that

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -492,6 +492,8 @@ set(SLIC3R_GUI_SOURCES
     GUI/Widgets/ErrorMsgStaticText.hpp
     GUI/Widgets/FanControl.cpp
     GUI/Widgets/FanControl.hpp
+    GUI/Widgets/HyperLink.cpp
+    GUI/Widgets/HyperLink.hpp
     GUI/Widgets/ImageSwitchButton.cpp
     GUI/Widgets/ImageSwitchButton.hpp
     GUI/Widgets/Label.cpp

--- a/src/slic3r/GUI/AMSMaterialsSetting.cpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.cpp
@@ -298,11 +298,7 @@ void AMSMaterialsSetting::create_panel_kn(wxWindow* parent)
     if (language.find("zh") == 0)
         region = "zh";
     wxString link_url = wxString::Format("https://wiki.bambulab.com/%s/software/bambu-studio/calibration_pa", region);
-    m_wiki_ctrl = new wxHyperlinkCtrl(parent, wxID_ANY, "Wiki", link_url);
-    m_wiki_ctrl->SetNormalColour(*wxBLUE);
-    m_wiki_ctrl->SetHoverColour(wxColour(0, 0, 200));
-    m_wiki_ctrl->SetVisitedColour(*wxBLUE);
-    m_wiki_ctrl->SetFont(Label::Head_14);
+    m_wiki_ctrl = new HyperLink(parent, "Wiki Guide", link_url);
     cali_title_sizer->Add(m_ratio_text, 0, wxALIGN_CENTER_VERTICAL);
     cali_title_sizer->Add(m_wiki_ctrl, 0, wxALIGN_CENTER_VERTICAL);
 

--- a/src/slic3r/GUI/AMSMaterialsSetting.hpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.hpp
@@ -14,8 +14,8 @@
 #include "Widgets/CheckBox.hpp"
 #include "Widgets/ComboBox.hpp"
 #include "Widgets/TextInput.hpp"
+#include "Widgets/HyperLink.hpp"
 #include "slic3r/Utils/CalibUtils.hpp"
-#include <wx/hyperlink.h>
 
 #define AMS_MATERIALS_SETTING_DEF_COLOUR wxColour(255, 255, 255)
 #define AMS_MATERIALS_SETTING_GREY900 wxColour(38, 46, 48)
@@ -174,7 +174,7 @@ protected:
 
     wxPanel *           m_panel_kn;
     wxStaticText*       m_ratio_text;
-    wxHyperlinkCtrl *   m_wiki_ctrl;
+    HyperLink *         m_wiki_ctrl;
     wxStaticText*       m_k_param;
     TextInput*          m_input_k_val;
     wxStaticText*       m_n_param;

--- a/src/slic3r/GUI/BindDialog.cpp
+++ b/src/slic3r/GUI/BindDialog.cpp
@@ -98,18 +98,8 @@ PingCodeBindDialog::PingCodeBindDialog(Plater* plater /*= nullptr*/)
     m_status_text->Wrap(FromDIP(440));
     m_status_text->SetForegroundColour(wxColour(38, 46, 48));
 
-    m_link_show_ping_code_wiki = new wxStaticText(request_bind_panel, wxID_ANY, _L("Can't find Pin Code?"));
-    m_link_show_ping_code_wiki->SetFont(Label::Body_14);
-    m_link_show_ping_code_wiki->SetBackgroundColour(*wxWHITE);
-    m_link_show_ping_code_wiki->SetForegroundColour(wxColour(31, 142, 234));
-
-    m_link_show_ping_code_wiki->Bind(wxEVT_ENTER_WINDOW, [this](auto& e) {SetCursor(wxCURSOR_HAND); });
-    m_link_show_ping_code_wiki->Bind(wxEVT_LEAVE_WINDOW, [this](auto& e) {SetCursor(wxCURSOR_ARROW); });
-
-    m_link_show_ping_code_wiki->Bind(wxEVT_LEFT_DOWN, [this](auto& e) {
-        m_ping_code_wiki = "https://wiki.bambulab.com/en/bambu-studio/manual/pin-code";
-        wxLaunchDefaultBrowser(m_ping_code_wiki);
-    });
+    // ORCA standardized HyperLink
+    m_link_show_ping_code_wiki = new HyperLink(request_bind_panel, _L("Can't find Pin Code?"), "https://wiki.bambulab.com/en/bambu-studio/manual/pin-code");
 
     m_text_input_title = new wxStaticText(request_bind_panel, wxID_ANY, _L("Pin Code"));
     m_text_input_title->SetFont(Label::Body_14);
@@ -453,11 +443,11 @@ PingCodeBindDialog::~PingCodeBindDialog() {
      m_st_privacy_title->SetFont(Label::Body_13);
      m_st_privacy_title->SetForegroundColour(wxColour(38, 46, 48));
 
-     auto m_link_Terms_title = new Label(m_panel_agreement, _L("Terms and Conditions"));
+     // ORCA standardized HyperLink
+     auto m_link_Terms_title = new HyperLink(m_panel_agreement, _L("Terms and Conditions"));
      m_link_Terms_title->SetFont(Label::Head_13);
      m_link_Terms_title->SetMaxSize(wxSize(FromDIP(450), -1));
      m_link_Terms_title->Wrap(FromDIP(450));
-     m_link_Terms_title->SetForegroundColour(wxColour("#009688"));
      m_link_Terms_title->Bind(wxEVT_LEFT_DOWN, [this](auto& e) {
          wxString txt = _L("Thank you for purchasing a Bambu Lab device. Before using your Bambu Lab device, please read the terms and conditions. "
                            "By clicking to agree to use your Bambu Lab device, you agree to abide by the Privacy Policy and Terms of Use (collectively, the \"Terms\"). "
@@ -467,18 +457,16 @@ PingCodeBindDialog::~PingCodeBindDialog() {
          confirm_dlg.CenterOnParent();
          confirm_dlg.on_show();
      });
-     m_link_Terms_title->Bind(wxEVT_ENTER_WINDOW, [this](auto& e) {SetCursor(wxCURSOR_HAND); });
-     m_link_Terms_title->Bind(wxEVT_LEAVE_WINDOW, [this](auto& e) {SetCursor(wxCURSOR_ARROW); });
 
      auto m_st_and_title = new Label(m_panel_agreement, _L("and"));
      m_st_and_title->SetFont(Label::Body_13);
      m_st_and_title->SetForegroundColour(wxColour(38, 46, 48));
 
-     auto m_link_privacy_title = new Label(m_panel_agreement, _L("Privacy Policy"));
+     // ORCA standardized HyperLink
+     auto m_link_privacy_title = new HyperLink(m_panel_agreement, _L("Privacy Policy"));
      m_link_privacy_title->SetFont(Label::Head_13);
      m_link_privacy_title->SetMaxSize(wxSize(FromDIP(450), -1));
      m_link_privacy_title->Wrap(FromDIP(450));
-     m_link_privacy_title->SetForegroundColour(wxColour("#009688"));
      m_link_privacy_title->Bind(wxEVT_LEFT_DOWN, [this](auto& e) {
          std::string url;
          std::string country_code = Slic3r::GUI::wxGetApp().app_config->get_country_code();
@@ -491,8 +479,6 @@ PingCodeBindDialog::~PingCodeBindDialog() {
          }
          wxLaunchDefaultBrowser(url);
      });
-     m_link_privacy_title->Bind(wxEVT_ENTER_WINDOW, [this](auto& e) {SetCursor(wxCURSOR_HAND);});
-     m_link_privacy_title->Bind(wxEVT_LEAVE_WINDOW, [this](auto& e) {SetCursor(wxCURSOR_ARROW);});
 
      sizere_notice_agreement->Add(0, 0, 0, wxTOP, FromDIP(4));
      sizer_privacy_agreement->Add(m_st_privacy_title, 0, wxALIGN_CENTER, 0);
@@ -514,13 +500,11 @@ PingCodeBindDialog::~PingCodeBindDialog() {
      m_st_notice_title->SetFont(Label::Body_13);
      m_st_notice_title->SetForegroundColour(wxColour(38, 46, 48));
 
-     auto m_link_notice_title = new Label(m_panel_agreement, notice_link_title);
+     // ORCA standardized HyperLink
+     auto m_link_notice_title = new HyperLink(m_panel_agreement, notice_link_title);
      m_link_notice_title->SetFont(Label::Head_13);
      m_link_notice_title->SetMaxSize(wxSize(FromDIP(450), -1));
      m_link_notice_title->Wrap(FromDIP(450));
-     m_link_notice_title->SetForegroundColour(wxColour("#009688"));
-     m_link_notice_title->Bind(wxEVT_ENTER_WINDOW, [this](auto& e) {SetCursor(wxCURSOR_HAND); });
-     m_link_notice_title->Bind(wxEVT_LEAVE_WINDOW, [this](auto& e) {SetCursor(wxCURSOR_ARROW); });
      m_link_notice_title->Bind(wxEVT_LEFT_DOWN, [this](auto& e) {
          wxString txt = _L("In the 3D Printing community, we learn from each other's successes and failures to adjust "
                            "our own slicing parameters and settings. %s follows the same principle and uses machine "
@@ -580,13 +564,8 @@ PingCodeBindDialog::~PingCodeBindDialog() {
      wxBoxSizer* m_sizer_bind_failed_info = new wxBoxSizer(wxVERTICAL);
      m_sw_bind_failed_info->SetSizer( m_sizer_bind_failed_info );
 
-     m_link_network_state = new wxHyperlinkCtrl(m_sw_bind_failed_info, wxID_ANY,_L("Check the status of current system services"),"");
-     m_link_network_state->SetFont(::Label::Body_12);
-     m_link_network_state->Bind(wxEVT_LEFT_DOWN, [this](auto& e) {wxGetApp().link_to_network_check(); });
-     m_link_network_state->Bind(wxEVT_ENTER_WINDOW, [this](auto& e) {m_link_network_state->SetCursor(wxCURSOR_HAND); });
-     m_link_network_state->Bind(wxEVT_LEAVE_WINDOW, [this](auto& e) {m_link_network_state->SetCursor(wxCURSOR_ARROW); });
-
-
+     // ORCA standardized HyperLink
+     m_link_network_state = new HyperLink(m_sw_bind_failed_info, _L("Check the status of current system services"), wxGetApp().link_to_network_check());
 
      wxBoxSizer* sizer_error_code = new wxBoxSizer(wxHORIZONTAL);
      wxBoxSizer* sizer_error_desc = new wxBoxSizer(wxHORIZONTAL);

--- a/src/slic3r/GUI/BindDialog.hpp
+++ b/src/slic3r/GUI/BindDialog.hpp
@@ -17,13 +17,13 @@
 #include <wx/dialog.h>
 #include <curl/curl.h>
 #include <wx/webrequest.h>
-#include <wx/hyperlink.h>
 #include "wxExtensions.hpp"
 #include "Widgets/StepCtrl.hpp"
 #include "Widgets/ProgressDialog.hpp"
 #include "Widgets/Button.hpp"
 #include "Widgets/ProgressBar.hpp"
 #include "Widgets/RoundedRectangle.hpp"
+#include "Widgets/HyperLink.hpp"
 #include "Jobs/BindJob.hpp"
 #include "BBLStatusBar.hpp"
 #include "BBLStatusBarBind.hpp"
@@ -56,7 +56,7 @@ private:
 
     Label* m_status_text;
     wxStaticText* m_text_input_title;
-    wxStaticText* m_link_show_ping_code_wiki;
+    HyperLink* m_link_show_ping_code_wiki; // ORCA
     TextInput* m_text_input_single_code[PING_CODE_LENGTH];
     Button* m_button_bind;
     Button* m_button_cancel;
@@ -70,7 +70,7 @@ private:
     Label* m_st_txt_error_code{ nullptr };
     Label* m_st_txt_error_desc{ nullptr };
     Label* m_st_txt_extra_info{ nullptr };
-    wxHyperlinkCtrl* m_link_network_state{ nullptr };
+    HyperLink*      m_link_network_state{ nullptr };
     wxString        m_result_info;
     wxString        m_result_extra;
     wxString        m_ping_code_wiki;
@@ -114,7 +114,7 @@ private:
     Label*          m_st_txt_error_code{ nullptr };
     Label*          m_st_txt_error_desc{ nullptr };
     Label*          m_st_txt_extra_info{ nullptr };
-    wxHyperlinkCtrl* m_link_network_state{ nullptr };
+    HyperLink*      m_link_network_state{ nullptr };
     wxString        m_result_info;
     wxString        m_result_extra;
     bool            m_show_error_info_state = true;

--- a/src/slic3r/GUI/CalibrationWizardPage.cpp
+++ b/src/slic3r/GUI/CalibrationWizardPage.cpp
@@ -466,21 +466,12 @@ void CaliPageCaption::init_bitmaps() {
 
 void CaliPageCaption::create_wiki(wxWindow* parent)
 {
-    m_wiki_text = new Label(parent, _L("Wiki"));
-    m_wiki_text->SetFont(Label::Head_14);
-    m_wiki_text->SetForegroundColour({ 0, 88, 220 });
-    m_wiki_text->Bind(wxEVT_ENTER_WINDOW, [this](wxMouseEvent& e) {
-        e.Skip();
-        SetCursor(wxCURSOR_HAND);
-        });
-    m_wiki_text->Bind(wxEVT_LEAVE_WINDOW, [this](wxMouseEvent& e) {
-        e.Skip();
-        SetCursor(wxCURSOR_ARROW);
-        });
+    // ORCA standardized HyperLink
+    m_wiki_text = new HyperLink(parent, _L("Wiki Guide"));
     m_wiki_text->Bind(wxEVT_LEFT_UP, [this](wxMouseEvent& e) {
         if (!m_wiki_url.empty())
             wxLaunchDefaultBrowser(m_wiki_url);
-        });
+    });
 }
 
 void CaliPageCaption::show_prev_btn(bool show)

--- a/src/slic3r/GUI/CalibrationWizardPage.hpp
+++ b/src/slic3r/GUI/CalibrationWizardPage.hpp
@@ -7,6 +7,7 @@
 #include "Widgets/TextInput.hpp"
 #include "Widgets/AMSControl.hpp"
 #include "Widgets/ProgressBar.hpp"
+#include "Widgets/HyperLink.hpp"
 #include "wxExtensions.hpp"
 #include "PresetComboBoxes.hpp"
 
@@ -140,7 +141,7 @@ private:
     void init_bitmaps();
     void create_wiki(wxWindow* parent);
 
-    Label* m_wiki_text;
+    HyperLink* m_wiki_text; // ORCA
     wxString  m_wiki_url;
     ScalableBitmap m_prev_bmp_normal;
     ScalableBitmap m_prev_bmp_hover;

--- a/src/slic3r/GUI/CreatePresetsDialog.cpp
+++ b/src/slic3r/GUI/CreatePresetsDialog.cpp
@@ -17,6 +17,7 @@
 #include "Tab.hpp"
 #include "MainFrame.hpp"
 #include "libslic3r_version.h"
+#include "Widgets/HyperLink.hpp" // ORCA
 
 #define NAME_OPTION_COMBOBOX_SIZE wxSize(FromDIP(200), FromDIP(24))
 #define FILAMENT_PRESET_COMBOBOX_SIZE wxSize(FromDIP(300), FromDIP(24))
@@ -5027,8 +5028,8 @@ wxPanel *PresetTree::get_child_item(wxPanel *parent, std::shared_ptr<Preset> pre
     bool base_id_error = false;
     if (preset->inherits() == "" && preset->base_id != "") base_id_error = true;
     if (base_id_error) {
-        std::string      wiki_url             = "https://wiki.bambulab.com/en/software/bambu-studio/custom-filament-issue";
-        wxHyperlinkCtrl *m_download_hyperlink = new wxHyperlinkCtrl(panel, wxID_ANY, _L("[Delete Required]"), wiki_url, wxDefaultPosition, wxDefaultSize, wxHL_DEFAULT_STYLE);
+        // ORCA standardized HyperLink
+        HyperLink *m_download_hyperlink = new HyperLink(panel, _L("[Delete Required]"), "https://wiki.bambulab.com/en/software/bambu-studio/custom-filament-issue");
         m_download_hyperlink->SetFont(Label::Body_10);
         sizer->Add(m_download_hyperlink, 0, wxEXPAND | wxALL, 5);
     }

--- a/src/slic3r/GUI/DownloadProgressDialog.cpp
+++ b/src/slic3r/GUI/DownloadProgressDialog.cpp
@@ -23,6 +23,8 @@
 #include "Jobs/BoostThreadWorker.hpp"
 #include "Jobs/PlaterWorker.hpp"
 
+#include "Widgets/HyperLink.hpp" // ORCA
+
 #define DESIGN_INPUT_SIZE wxSize(FromDIP(100), -1)
 
 namespace Slic3r {
@@ -72,7 +74,8 @@ DownloadProgressDialog::DownloadProgressDialog(wxString title)
 
     sizer_download_failed->Add(m_statictext_download_failed, 0, wxALIGN_CENTER | wxALL, 5);
 
-    auto m_download_hyperlink = new wxHyperlinkCtrl(m_panel_download_failed, wxID_ANY, _L("click here to see more info"), download_failed_url, wxDefaultPosition, wxDefaultSize, wxHL_DEFAULT_STYLE);
+    // ORCA standardized HyperLink
+    auto m_download_hyperlink = new HyperLink(m_panel_download_failed, _L("click here to see more info"), download_failed_url);
     sizer_download_failed->Add(m_download_hyperlink, 0, wxALIGN_CENTER | wxALL, 5);
 
 
@@ -93,7 +96,8 @@ DownloadProgressDialog::DownloadProgressDialog(wxString title)
 
     sizer_install_failed->Add(m_statictext_install_failed, 0, wxALIGN_CENTER | wxALL, 5);
 
-    auto m_install_hyperlink = new wxHyperlinkCtrl(m_panel_install_failed, wxID_ANY, _L("click here to see more info"), install_failed_url, wxDefaultPosition, wxDefaultSize, wxHL_DEFAULT_STYLE);
+    // ORCA standardized HyperLink
+    auto m_install_hyperlink = new HyperLink(m_panel_install_failed, _L("click here to see more info"), install_failed_url);
     sizer_install_failed->Add(m_install_hyperlink, 0, wxALIGN_CENTER | wxALL, 5);
 
 

--- a/src/slic3r/GUI/FilamentGroupPopup.cpp
+++ b/src/slic3r/GUI/FilamentGroupPopup.cpp
@@ -147,15 +147,10 @@ FilamentGroupPopup::FilamentGroupPopup(wxWindow *parent) : PopupWindow(parent, w
     {
         wxBoxSizer *button_sizer = new wxBoxSizer(wxHORIZONTAL);
 
-        const std::string wiki_path = Slic3r::resources_dir() + "/wiki/filament_group_wiki_zh.html";
+        const std::string wiki_path = Slic3r::resources_dir() + "/wiki/filament_group_wiki_zh.html"; // NEEDFIX this link is broken
 
         auto* wiki_sizer = new wxBoxSizer(wxHORIZONTAL);
-        wiki_link = new wxStaticText(this, wxID_ANY, _L("Learn more"));
-        wiki_link->SetBackgroundColour(BackGroundColor);
-        wiki_link->SetForegroundColour(GreenColor);
-        wiki_link->SetFont(Label::Body_12.Underlined());
-        wiki_link->SetCursor(wxCursor(wxCURSOR_HAND));
-        wiki_link->Bind(wxEVT_LEFT_DOWN, [wiki_path](wxMouseEvent &) { wxLaunchDefaultBrowser(wxString(wiki_path.c_str())); });
+        wiki_link = new HyperLink(this, _L("Wiki Guide"), wxString(wiki_path.c_str())); // ORCA
         wiki_sizer->Add(wiki_link, 0, wxALIGN_CENTER | wxALL, FromDIP(3));
 
         button_sizer->Add(wiki_sizer, 0, wxLEFT, horizontal_margin);

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -3414,7 +3414,7 @@ void GUI_App::set_side_menu_popup_status(bool status)
     m_side_popup_status = status;
 }
 
-void GUI_App::link_to_network_check()
+std::string GUI_App::link_to_network_check()
 {
     std::string url;
     std::string country_code = app_config->get_country_code();
@@ -3429,10 +3429,11 @@ void GUI_App::link_to_network_check()
     else {
         url = "https://status.bambulab.com";
     }
-    wxLaunchDefaultBrowser(url);
+    //wxLaunchDefaultBrowser(url);
+    return url; // ORCA
 }
 
-void GUI_App::link_to_lan_only_wiki()
+std::string GUI_App::link_to_lan_only_wiki()
 {
     std::string url;
     std::string country_code = app_config->get_country_code();
@@ -3446,7 +3447,8 @@ void GUI_App::link_to_lan_only_wiki()
     else {
         url = "https://wiki.bambulab.com/en/knowledge-sharing/enable-lan-mode";
     }
-    wxLaunchDefaultBrowser(url);
+    //wxLaunchDefaultBrowser(url);
+    return url; // ORCA
 }
 
 bool GUI_App::tabs_as_menu() const

--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -406,8 +406,8 @@ public:
     //update side popup status
     bool            get_side_menu_popup_status();
     void            set_side_menu_popup_status(bool status);
-    void            link_to_network_check();
-    void            link_to_lan_only_wiki();
+    std::string     link_to_network_check(); // ORCA
+    std::string     link_to_lan_only_wiki(); // ORCA
 
     const wxColour& get_label_clr_modified() { return m_color_label_modified; }
     const wxColour& get_label_clr_sys()     { return m_color_label_sys; }

--- a/src/slic3r/GUI/MsgDialog.cpp
+++ b/src/slic3r/GUI/MsgDialog.cpp
@@ -586,7 +586,8 @@ wxBoxSizer *Newer3mfVersionDialog::get_msg_sizer()
     if (file_version_newer) { 
         text1 = new wxStaticText(this, wxID_ANY, _L("The 3MF file version is in Beta and it is newer than the current OrcaSlicer version."));
         wxStaticText *   text2       = new wxStaticText(this, wxID_ANY, _L("If you would like to try Orca Slicer Beta, you may click to"));
-        wxHyperlinkCtrl *github_link = new wxHyperlinkCtrl(this, wxID_ANY, _L("Download Beta Version"), "https://github.com/bambulab/BambuStudio/releases");
+        // ORCA standardized HyperLink
+        HyperLink *      github_link = new HyperLink(this, _L("Download Beta Version"), "https://github.com/SoftFever/OrcaSlicer/releases");
         horizontal_sizer->Add(text2, 0, wxEXPAND, 0);
         horizontal_sizer->Add(github_link, 0, wxEXPAND | wxLEFT, 5);
         
@@ -672,11 +673,9 @@ NetworkErrorDialog::NetworkErrorDialog(wxWindow* parent)
 
     wxBoxSizer* sizer_link = new wxBoxSizer(wxVERTICAL);
 
-    m_link_server_state = new wxHyperlinkCtrl(this, wxID_ANY, _L("Check the status of current system services"), "");
+    // ORCA standardized HyperLink
+    m_link_server_state = new HyperLink(this, _L("Check the status of current system services"), wxGetApp().link_to_network_check());
     m_link_server_state->SetFont(::Label::Body_13);
-    m_link_server_state->Bind(wxEVT_LEFT_DOWN, [this](auto& e) {wxGetApp().link_to_network_check(); });
-    m_link_server_state->Bind(wxEVT_ENTER_WINDOW, [this](auto& e) {SetCursor(wxCURSOR_HAND); });
-    m_link_server_state->Bind(wxEVT_LEAVE_WINDOW, [this](auto& e) {SetCursor(wxCURSOR_ARROW); });
 
     sizer_link->Add(m_link_server_state, 0, wxALL, 0);
 
@@ -690,11 +689,9 @@ NetworkErrorDialog::NetworkErrorDialog(wxWindow* parent)
     m_text_proposal->SetFont(::Label::Body_14);
     m_text_proposal->SetForegroundColour(0x323A3C);
 
-    m_text_wiki = new wxHyperlinkCtrl(this, wxID_ANY, _L("How to use LAN only mode"), "");
+    // ORCA standardized HyperLink
+    m_text_wiki = new HyperLink(this, _L("How to use LAN only mode"), wxGetApp().link_to_lan_only_wiki());
     m_text_wiki->SetFont(::Label::Body_13);
-    m_text_wiki->Bind(wxEVT_LEFT_DOWN, [this](auto& e) {wxGetApp().link_to_lan_only_wiki(); });
-    m_text_wiki->Bind(wxEVT_ENTER_WINDOW, [this](auto& e) {SetCursor(wxCURSOR_HAND); });
-    m_text_wiki->Bind(wxEVT_LEAVE_WINDOW, [this](auto& e) {SetCursor(wxCURSOR_ARROW); });
 
     sizer_help->Add(m_text_proposal, 0, wxEXPAND, 0);
     sizer_help->Add(m_text_wiki, 0, wxALL, 0);

--- a/src/slic3r/GUI/MsgDialog.hpp
+++ b/src/slic3r/GUI/MsgDialog.hpp
@@ -14,6 +14,7 @@
 #include "Widgets/Button.hpp"
 #include "Widgets/CheckBox.hpp"
 #include "Widgets/TextInput.hpp"
+#include "Widgets/HyperLink.hpp"
 #include "BBLStatusBar.hpp"
 #include "BBLStatusBarSend.hpp"
 #include "libslic3r/Semver.hpp"
@@ -424,9 +425,9 @@ public:
 
 private:
     Label* m_text_basic;
-    wxHyperlinkCtrl* m_link_server_state;
+    HyperLink* m_link_server_state; // ORCA
     Label* m_text_proposal;
-    wxHyperlinkCtrl* m_text_wiki;
+    HyperLink* m_text_wiki; // ORCA
     Button *         m_button_confirm;
 
 public:

--- a/src/slic3r/GUI/NotificationManager.hpp
+++ b/src/slic3r/GUI/NotificationManager.hpp
@@ -980,7 +980,7 @@ private:
 
         NotificationData{NotificationType::BBLUserPresetExceedLimit, NotificationLevel::WarningNotificationLevel, BBL_NOTICE_MAX_INTERVAL,
 			_u8L("The number of user presets cached in the cloud has exceeded the upper limit, newly created user presets can only be used locally."), 
-			_u8L("Wiki"),
+			_u8L("Wiki Guide"),
                          [](wxEvtHandler* evnthndlr) {
 				wxLaunchDefaultBrowser("https://wiki.bambulab.com/en/software/bambu-studio/3rd-party-printer-profile#cloud-user-presets-limit");
 				return false;

--- a/src/slic3r/GUI/ObjColorDialog.cpp
+++ b/src/slic3r/GUI/ObjColorDialog.cpp
@@ -47,14 +47,7 @@ wxBoxSizer* ObjColorDialog::create_btn_sizer(long flags,bool exist_error)
     auto btn_sizer = new wxBoxSizer(wxHORIZONTAL);
     if (!exist_error) {
         btn_sizer->AddSpacer(FromDIP(25));
-        wxStaticText *tips = new wxStaticText(this, wxID_ANY, _L("Open Wiki for more information >"));
-        /* wxFont        font(10, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false);
-         font.SetUnderlined(true);
-         tips->SetFont(font);*/
-        auto font = tips->GetFont();
-        font.SetUnderlined(true);
-        tips->SetFont(font);
-        tips->SetForegroundColour(wxColour("#009687"));
+        auto *tips = new HyperLink(this, _L("Wiki Guide")); // ORCA
         tips->Bind(wxEVT_LEFT_DOWN, [this](wxMouseEvent &e) {
             bool is_zh = wxGetApp().app_config->get("language") == "zh_CN";
             if (is_zh) {

--- a/src/slic3r/GUI/PrintOptionsDialog.cpp
+++ b/src/slic3r/GUI/PrintOptionsDialog.cpp
@@ -1153,11 +1153,8 @@ PrinterPartsDialog::PrinterPartsDialog(wxWindow* parent)
     change_nozzle_tips->SetFont(Label::Body_13);
     change_nozzle_tips->SetForegroundColour(STATIC_TEXT_CAPTION_COL);
 
-    m_wiki_link = new Label(single_panel, _L("View wiki"));
+    m_wiki_link = new HyperLink(single_panel, _L("Wiki Guide")); // ORCA
     m_wiki_link->SetFont(Label::Body_13);
-    m_wiki_link->SetForegroundColour(wxColour("#009688"));
-    m_wiki_link->Bind(wxEVT_ENTER_WINDOW, [this](auto& e) { SetCursor(wxCURSOR_HAND); });
-    m_wiki_link->Bind(wxEVT_LEAVE_WINDOW, [this](auto& e) { SetCursor(wxCURSOR_ARROW); });
     m_wiki_link->Bind(wxEVT_LEFT_DOWN, &PrinterPartsDialog::OnWikiClicked, this);
 
     h_tips_sizer->Add(change_nozzle_tips, 0, wxLEFT);
@@ -1267,11 +1264,8 @@ PrinterPartsDialog::PrinterPartsDialog(wxWindow* parent)
     multiple_change_nozzle_tips->SetFont(Label::Body_13);
     multiple_change_nozzle_tips->SetForegroundColour(STATIC_TEXT_CAPTION_COL);
 
-    multiple_wiki_link = new Label(multiple_panel, _L("View wiki"));
+    multiple_wiki_link = new HyperLink(multiple_panel, _L("Wiki Guide")); // ORCA
     multiple_wiki_link->SetFont(Label::Body_13);
-    multiple_wiki_link->SetForegroundColour(wxColour("#009688"));
-    multiple_wiki_link->Bind(wxEVT_ENTER_WINDOW, [this](auto& e) { SetCursor(wxCURSOR_HAND); });
-    multiple_wiki_link->Bind(wxEVT_LEAVE_WINDOW, [this](auto& e) { SetCursor(wxCURSOR_ARROW); });
     multiple_wiki_link->Bind(wxEVT_LEFT_DOWN, &PrinterPartsDialog::OnWikiClicked, this);
 
     wxSizer* multiple_change_tips_sizer = new wxBoxSizer(wxHORIZONTAL);

--- a/src/slic3r/GUI/PrintOptionsDialog.hpp
+++ b/src/slic3r/GUI/PrintOptionsDialog.hpp
@@ -16,6 +16,7 @@
 #include "Widgets/CheckBox.hpp"
 #include "Widgets/StaticLine.hpp"
 #include "Widgets/ComboBox.hpp"
+#include "Widgets/HyperLink.hpp"
 
 // Previous definitions
 class SwitchBoard;
@@ -33,7 +34,7 @@ protected:
     Label*    nozzle_flow_type_label;
     ComboBox* nozzle_flow_type_checkbox;
     Label    *change_nozzle_tips;
-    Label* m_wiki_link;
+    HyperLink* m_wiki_link;
     Button* m_single_update_nozzle_button;
     Button* m_multiple_update_nozzle_button;
 
@@ -46,7 +47,7 @@ protected:
     ComboBox *multiple_right_nozzle_flow_checkbox;
 
     Label *multiple_change_nozzle_tips;
-    Label* multiple_wiki_link;
+    HyperLink* multiple_wiki_link;
 
     wxPanel *single_panel;
     wxPanel *multiple_panel;

--- a/src/slic3r/GUI/ReleaseNote.cpp
+++ b/src/slic3r/GUI/ReleaseNote.cpp
@@ -1510,7 +1510,8 @@ InputIpAddressDialog::InputIpAddressDialog(wxWindow *parent)
     m_tip4->SetMinSize(wxSize(FromDIP(355), -1));
     m_tip4->SetMaxSize(wxSize(FromDIP(355), -1));
 
-    m_trouble_shoot = new wxHyperlinkCtrl(this, wxID_ANY, "How to trouble shooting", "");
+    // ORCA standardized HyperLink
+    m_trouble_shoot = new HyperLink(this, "How to trouble shooting");
 
     m_img_help = new wxStaticBitmap(this, wxID_ANY, create_scaled_bitmap("input_access_code_x1_en", this, 198), wxDefaultPosition, wxSize(FromDIP(355), -1), 0);
 

--- a/src/slic3r/GUI/ReleaseNote.hpp
+++ b/src/slic3r/GUI/ReleaseNote.hpp
@@ -326,7 +326,7 @@ public:
     wxStaticBitmap* m_img_step1{ nullptr };
     wxStaticBitmap* m_img_step2{ nullptr };
     wxStaticBitmap* m_img_step3{ nullptr };
-    wxHyperlinkCtrl* m_trouble_shoot{ nullptr };
+    HyperLink* m_trouble_shoot{ nullptr }; // ORCA
     wxTimer* closeTimer{ nullptr };
     int     closeCount{3};
     bool   m_show_access_code{ false };

--- a/src/slic3r/GUI/SelectMachine.cpp
+++ b/src/slic3r/GUI/SelectMachine.cpp
@@ -688,12 +688,9 @@ SelectMachineDialog::SelectMachineDialog(Plater *plater)
     sizer_extra_info->Add(st_title_extra_info_doc, 0, wxALL, 0);
     sizer_extra_info->Add(m_st_txt_extra_info, 0, wxALL, 0);
 
-
-    m_link_network_state = new wxHyperlinkCtrl(m_sw_print_failed_info, wxID_ANY,_L("Check the status of current system services"),"");
+    // ORCA standardized HyperLink
+    m_link_network_state = new HyperLink(m_sw_print_failed_info, _L("Check the status of current system services"), wxGetApp().link_to_network_check());
     m_link_network_state->SetFont(::Label::Body_12);
-    m_link_network_state->Bind(wxEVT_LEFT_DOWN, [this](auto& e) {wxGetApp().link_to_network_check();});
-    m_link_network_state->Bind(wxEVT_ENTER_WINDOW, [this](auto& e) {m_link_network_state->SetCursor(wxCURSOR_HAND);});
-    m_link_network_state->Bind(wxEVT_LEAVE_WINDOW, [this](auto& e) {m_link_network_state->SetCursor(wxCURSOR_ARROW);});
 
     sizer_print_failed_info->Add(m_link_network_state, 0, wxLEFT, 5);
     sizer_print_failed_info->Add(sizer_error_code, 0, wxLEFT, 5);

--- a/src/slic3r/GUI/SelectMachine.hpp
+++ b/src/slic3r/GUI/SelectMachine.hpp
@@ -42,6 +42,7 @@
 #include "Widgets/ComboBox.hpp"
 #include "Widgets/ScrolledWindow.hpp"
 #include "Widgets/PopupWindow.hpp"
+#include "Widgets/HyperLink.hpp" // ORCA
 #include <wx/simplebook.h>
 #include <wx/hashmap.h>
 
@@ -371,7 +372,7 @@ protected:
     Label*                              m_st_txt_error_desc{nullptr};
     Label*                              m_st_txt_extra_info{nullptr};
     Label*                              m_ams_backup_tip{nullptr};
-    wxHyperlinkCtrl*                    m_link_network_state{ nullptr };
+    HyperLink*                          m_link_network_state{ nullptr }; // ORCA
     wxSimplebook*                       m_rename_switch_panel{nullptr};
     wxSimplebook*                       m_simplebook{nullptr};
     wxStaticText*                       m_rename_text{nullptr};

--- a/src/slic3r/GUI/SelectMachinePop.cpp
+++ b/src/slic3r/GUI/SelectMachinePop.cpp
@@ -596,8 +596,9 @@ void SelectMachinePopup::update_other_devices()
     m_placeholder_panel = new wxWindow(m_scrolledWindow, wxID_ANY, wxDefaultPosition, wxSize(-1,FromDIP(26)));
     wxBoxSizer* placeholder_sizer = new wxBoxSizer(wxVERTICAL);
 
-    m_hyperlink = new wxHyperlinkCtrl(m_placeholder_panel, wxID_ANY, _L("Can't find my devices?"), wxT("https://wiki.bambulab.com/en/software/bambu-studio/failed-to-connect-printer"), wxDefaultPosition, wxDefaultSize, wxHL_DEFAULT_STYLE);
-    m_hyperlink->SetNormalColour(StateColor::darkModeColorFor("#009789"));
+    // ORCA standardized HyperLink
+    m_hyperlink = new HyperLink(m_placeholder_panel, _L("Can't find my devices?"), wxT("https://wiki.bambulab.com/en/software/bambu-studio/failed-to-connect-printer"));
+    m_hyperlink->SetFont(::Label::Body_12);
     placeholder_sizer->Add(m_hyperlink, 0, wxALIGN_CENTER | wxALL, 5);
 
 

--- a/src/slic3r/GUI/SelectMachinePop.hpp
+++ b/src/slic3r/GUI/SelectMachinePop.hpp
@@ -180,7 +180,7 @@ private:
     PinCodePanel*                     m_panel_ping_code{nullptr};
     PinCodePanel*                     m_panel_direct_connection{nullptr};
     wxWindow*                         m_placeholder_panel{nullptr};
-    wxHyperlinkCtrl*                  m_hyperlink{nullptr};
+    HyperLink*                        m_hyperlink{nullptr}; // ORCA
     Label*                            m_ping_code_text{nullptr};
     wxStaticBitmap*                   m_img_ping_code{nullptr};
     wxBoxSizer *                      m_sizer_body{nullptr};

--- a/src/slic3r/GUI/SendToPrinter.cpp
+++ b/src/slic3r/GUI/SendToPrinter.cpp
@@ -446,11 +446,9 @@ SendToPrinterDialog::SendToPrinterDialog(Plater *plater)
     sizer_extra_info->Add(st_title_extra_info_doc, 0, wxALL, 0);
     sizer_extra_info->Add(m_st_txt_extra_info, 0, wxALL, 0);
 
-    m_link_network_state = new wxHyperlinkCtrl(m_sw_print_failed_info, wxID_ANY,_L("Check the status of current system services"),"");
+    // ORCA standardized HyperLink
+    m_link_network_state = new HyperLink(m_sw_print_failed_info, _L("Check the status of current system services"), wxGetApp().link_to_network_check());
     m_link_network_state->SetFont(::Label::Body_12);
-    m_link_network_state->Bind(wxEVT_LEFT_DOWN, [this](auto& e) {wxGetApp().link_to_network_check(); });
-    m_link_network_state->Bind(wxEVT_ENTER_WINDOW, [this](auto& e) {m_link_network_state->SetCursor(wxCURSOR_HAND); });
-    m_link_network_state->Bind(wxEVT_LEAVE_WINDOW, [this](auto& e) {m_link_network_state->SetCursor(wxCURSOR_ARROW); });
 
     sizer_print_failed_info->Add(m_link_network_state, 0, wxLEFT, 5);
     sizer_print_failed_info->Add(sizer_error_code, 0, wxLEFT, 5);

--- a/src/slic3r/GUI/SendToPrinter.hpp
+++ b/src/slic3r/GUI/SendToPrinter.hpp
@@ -110,7 +110,7 @@ private:
     Label*                              m_st_txt_error_code{ nullptr };
     Label*                              m_st_txt_error_desc{ nullptr };
     Label*                              m_st_txt_extra_info{ nullptr };
-    wxHyperlinkCtrl*                    m_link_network_state{ nullptr };
+    HyperLink*                          m_link_network_state{ nullptr };
     StateColor                          btn_bg_enable;
     wxBoxSizer*                         rename_sizer_v{ nullptr };
     wxBoxSizer*                         rename_sizer_h{ nullptr };

--- a/src/slic3r/GUI/StepMeshDialog.cpp
+++ b/src/slic3r/GUI/StepMeshDialog.cpp
@@ -117,14 +117,11 @@ StepMeshDialog::StepMeshDialog(wxWindow* parent, Slic3r::Step& file, double line
     wxBoxSizer* tips_sizer = new wxBoxSizer(wxVERTICAL);
     wxStaticText* info = new wxStaticText(this, wxID_ANY, _L("Smaller linear and angular deflections result in higher-quality transformations but increase the processing time."));
     info->SetForegroundColour(StateColor::darkModeColorFor(FONT_COLOR));
-    wxStaticText *tips = new wxStaticText(this, wxID_ANY, _L("View Wiki for more information"));
-    wxFont font(10, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false);
-    font.SetUnderlined(true);
-    tips->SetForegroundColour(StateColor::darkModeColorFor(wxColour(0, 151, 137)));
-    tips->SetFont(font);
-    tips->Bind(wxEVT_LEFT_DOWN, [this](wxMouseEvent& e) {
-        wxLaunchDefaultBrowser("https://www.orcaslicer.com/wiki/stl-transformation");
-    });
+
+    // ORCA standardized HyperLink
+    HyperLink *tips = new HyperLink(this, _L("Wiki Guide"), "https://www.orcaslicer.com/wiki/stl-transformation");
+    tips->SetFont(::Label::Body_12);
+ 
     info->Wrap(FromDIP(400));
     tips_sizer->Add(info, 0, wxALIGN_LEFT);
     tips_sizer->Add(tips, 0, wxALIGN_LEFT);

--- a/src/slic3r/GUI/WebUserLoginDialog.cpp
+++ b/src/slic3r/GUI/WebUserLoginDialog.cpp
@@ -25,6 +25,7 @@
 
 #include <sstream>
 #include <slic3r/GUI/Widgets/WebView.hpp>
+#include <slic3r/GUI/Widgets/HyperLink.hpp> // ORCA
 using namespace std;
 
 using namespace nlohmann;
@@ -57,11 +58,12 @@ ZUserLogin::ZUserLogin() : wxDialog((wxWindow *) (wxGetApp().mainframe), wxID_AN
         m_message->SetForegroundColour(*wxBLACK);
         m_message->Wrap(FromDIP(360));
 
-        auto m_download_hyperlink = new wxHyperlinkCtrl(this, wxID_ANY, _L("Click here to download it."), wxEmptyString, wxDefaultPosition, wxDefaultSize, wxHL_DEFAULT_STYLE);
-        m_download_hyperlink->Bind(wxEVT_HYPERLINK, [this](wxCommandEvent& event) {
+        // ORCA standardized HyperLink
+        auto m_download_hyperlink = new HyperLink(this, _L("Click here to download it."));
+        m_download_hyperlink->Bind(wxEVT_LEFT_DOWN, [this](wxMouseEvent& event) {
             this->Close();
             wxGetApp().ShowDownNetPluginDlg();
-            });
+        });
         m_sizer_main->Add(m_message, 0, wxALIGN_CENTER | wxALL, FromDIP(15));
         m_sizer_main->Add(m_download_hyperlink, 0, wxALIGN_CENTER | wxALL, FromDIP(10));
         m_sizer_main->Add(0, 0, 1, wxBOTTOM, 10);

--- a/src/slic3r/GUI/Widgets/HyperLink.cpp
+++ b/src/slic3r/GUI/Widgets/HyperLink.cpp
@@ -1,0 +1,49 @@
+#include "HyperLink.hpp"
+#include "Label.hpp"
+
+namespace Slic3r { namespace GUI {
+
+HyperLink::HyperLink(wxWindow* parent, const wxString& label, const wxString& url, long style)
+    : wxStaticText(parent, wxID_ANY, label)
+    , m_url(url)
+    , m_normalColor(wxColour("#009687")) // used slightly different color otherwise automatically uses ColorForDark that not visible enough
+    , m_hoverColor(wxColour("#26A69A"))
+{
+    SetForegroundColour(m_normalColor);
+    HyperLink::SetFont(Label::Head_14);
+    SetCursor(wxCursor(wxCURSOR_HAND));
+
+    if (!m_url.IsEmpty())
+        SetToolTip(m_url);
+
+    Bind(wxEVT_LEFT_DOWN, ([this](wxMouseEvent& e) {
+             if (!m_url.IsEmpty())
+                 wxLaunchDefaultBrowser(m_url);
+         }));
+
+    Bind(wxEVT_ENTER_WINDOW, ([this](wxMouseEvent& e) {
+             SetForegroundColour(m_hoverColor);
+             Refresh();
+         }));
+    Bind(wxEVT_LEAVE_WINDOW, ([this](wxMouseEvent& e) {
+             SetForegroundColour(m_normalColor);
+             Refresh();
+         }));
+}
+
+bool HyperLink::SetFont(const wxFont& font)
+{ // ensure it stays underlined
+    wxFont f = font;
+    f.SetUnderlined(true);
+    return wxStaticText::SetFont(f);
+}
+
+void HyperLink::SetURL(const wxString& url)
+{
+    m_url = url;
+    SetToolTip(m_url);
+}
+
+wxString HyperLink::GetURL() const { return m_url; }
+
+}} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/Widgets/HyperLink.hpp
+++ b/src/slic3r/GUI/Widgets/HyperLink.hpp
@@ -1,0 +1,26 @@
+#ifndef slic3r_GUI_HyperLink_hpp_
+#define slic3r_GUI_HyperLink_hpp_
+
+#include <wx/wx.h>
+#include <wx/window.h>
+
+namespace Slic3r { namespace GUI {
+
+class HyperLink : public wxStaticText
+{
+public:
+    HyperLink(wxWindow* parent, const wxString& label = wxEmptyString, const wxString& url = wxEmptyString, const long style = 0);
+
+    void     SetURL(const wxString& url);
+    wxString GetURL() const;
+
+    bool SetFont(const wxFont& font);
+
+private:
+    wxString m_url;
+    wxColour m_normalColor;
+    wxColour m_hoverColor;
+};
+
+}} // namespace Slic3r::GUI
+#endif // !slic3r_GUI_HyperLink_hpp_

--- a/src/slic3r/GUI/Widgets/SideTools.cpp
+++ b/src/slic3r/GUI/Widgets/SideTools.cpp
@@ -274,8 +274,8 @@ SideTools::SideTools(wxWindow *parent, wxWindowID id, const wxPoint &pos, const 
     wxBoxSizer* connection_sizer_V = new wxBoxSizer(wxVERTICAL);
     wxBoxSizer* connection_sizer_H = new wxBoxSizer(wxHORIZONTAL);
 
-    m_hyperlink = new wxHyperlinkCtrl(m_connection_info, wxID_ANY, _L("Failed to connect to the server"), wxT("https://wiki.bambulab.com/en/software/bambu-studio/failed-to-connect-printer"), wxDefaultPosition, wxDefaultSize, wxHL_DEFAULT_STYLE);
-    m_hyperlink->SetBackgroundColour(wxColour(255, 111, 0));
+    // ORCA standardized HyperLink
+    m_hyperlink = new HyperLink(m_connection_info, _L("Failed to connect to the server"), wxT("https://wiki.bambulab.com/en/software/bambu-studio/failed-to-connect-printer"));
 
     m_more_err_open = ScalableBitmap(this, "monitir_err_open", 16);
     m_more_err_close = ScalableBitmap(this, "monitir_err_close", 16);
@@ -328,13 +328,10 @@ SideTools::SideTools(wxWindow *parent, wxWindowID id, const wxPoint &pos, const 
     wxBoxSizer* sizer_error_desc = new wxBoxSizer(wxHORIZONTAL);
     wxBoxSizer* sizer_extra_info = new wxBoxSizer(wxHORIZONTAL);
 
-    m_link_network_state = new wxHyperlinkCtrl(m_side_error_panel, wxID_ANY,_L("Check the status of current system services"),"",wxDefaultPosition,wxDefaultSize, wxHL_ALIGN_CENTRE |wxST_ELLIPSIZE_END);
-    m_link_network_state->SetMinSize(wxSize(FromDIP(220), -1));
+    // ORCA standardized HyperLink
+    m_link_network_state = new HyperLink(m_side_error_panel, _L("Check the status of current system services"), wxGetApp().link_to_network_check(), wxST_ELLIPSIZE_END);
     m_link_network_state->SetMaxSize(wxSize(FromDIP(220), -1));
     m_link_network_state->SetFont(::Label::Body_12);
-    m_link_network_state->Bind(wxEVT_LEFT_DOWN, [this](auto& e) {wxGetApp().link_to_network_check(); });
-    m_link_network_state->Bind(wxEVT_ENTER_WINDOW, [this](auto& e) {m_link_network_state->SetCursor(wxCURSOR_HAND); });
-    m_link_network_state->Bind(wxEVT_LEAVE_WINDOW, [this](auto& e) {m_link_network_state->SetCursor(wxCURSOR_ARROW); });
 
     auto st_title_error_code = new wxStaticText(m_side_error_panel, wxID_ANY, _L("code"), wxDefaultPosition, wxDefaultSize, wxST_ELLIPSIZE_END);
     auto st_title_error_code_doc = new wxStaticText(m_side_error_panel, wxID_ANY, ": ");

--- a/src/slic3r/GUI/Widgets/SideTools.hpp
+++ b/src/slic3r/GUI/Widgets/SideTools.hpp
@@ -4,9 +4,9 @@
 #include <wx/dcgraph.h>
 #include <wx/gdicmn.h>
 #include <wx/dcclient.h>
-#include <wx/hyperlink.h>
 #include "Button.hpp"
 #include "Label.hpp"
+#include "HyperLink.hpp" // ORCA
 #include "../GUI/Tabbook.hpp"
 #include "../DeviceManager.hpp"
 #include "../wxExtensions.hpp"
@@ -99,13 +99,13 @@ public:
 private:
     SideToolsPanel* m_side_tools{ nullptr };
     Tabbook*        m_tabpanel{ nullptr };
-    wxHyperlinkCtrl* m_link_network_state{ nullptr };
+    HyperLink* m_link_network_state{ nullptr }; // ORCA
     Label* m_st_txt_error_code{ nullptr };
     Label* m_st_txt_error_desc{ nullptr };
     Label* m_st_txt_extra_info{ nullptr };
     wxWindow* m_side_error_panel{ nullptr };
     Button* m_connection_info{ nullptr };
-    wxHyperlinkCtrl* m_hyperlink{ nullptr };
+    HyperLink* m_hyperlink{ nullptr }; // ORCA
     ScalableButton* m_more_button{ nullptr };
     ScalableBitmap      m_more_err_open;
     ScalableBitmap      m_more_err_close;

--- a/src/slic3r/GUI/calib_dlg.cpp
+++ b/src/slic3r/GUI/calib_dlg.cpp
@@ -5,6 +5,7 @@
 #include <wx/dcgraph.h>
 #include "MainFrame.hpp"
 #include "Widgets/DialogButtons.hpp"
+#include "Widgets/HyperLink.hpp"
 #include <string>
 #include <vector>
 #include "libslic3r/PrintConfig.hpp"
@@ -173,22 +174,14 @@ PA_Calibration_Dlg::PA_Calibration_Dlg(wxWindow* parent, wxWindowID id, Plater* 
     v_sizer->Add(settings_sizer, 0, wxTOP | wxRIGHT | wxLEFT | wxEXPAND, FromDIP(10));
     v_sizer->AddSpacer(FromDIP(5));
 
-    // Help links
-    auto help_sizer = new wxBoxSizer(wxVERTICAL);
-    auto help_link_pa = new wxHyperlinkCtrl(this, wxID_ANY, _L("Pressure Advance Guide"),
-        "https://www.orcaslicer.com/wiki/pressure-advance-calib");
-    help_link_pa->SetForegroundColour(wxColour("#1890FF"));
-    help_sizer->Add(help_link_pa, 0, wxALL, FromDIP(5));
-
-    auto help_link_apa = new wxHyperlinkCtrl(this, wxID_ANY, _L("Adaptive Pressure Advance Guide"),
-        "https://www.orcaslicer.com/wiki/adaptive-pressure-advance-calib");
-    help_link_apa->SetForegroundColour(wxColour("#1890FF"));
-    help_sizer->Add(help_link_apa, 0, wxALL, FromDIP(5));
-
-    v_sizer->Add(help_sizer, 0, wxALL, FromDIP(10));
-
     auto dlg_btns = new DialogButtons(this, {"OK"});
-    v_sizer->Add(dlg_btns , 0, wxEXPAND);
+
+    auto bottom_sizer = new wxBoxSizer(wxHORIZONTAL);
+    auto wiki = new HyperLink(this, _L("Wiki Guide"), "https://www.orcaslicer.com/wiki/pressure-advance-calib");
+    bottom_sizer->Add(wiki, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, FromDIP(20));
+    bottom_sizer->AddStretchSpacer();
+    bottom_sizer->Add(dlg_btns, 0, wxEXPAND);
+    v_sizer->Add(bottom_sizer, 0, wxEXPAND);
 
     dlg_btns->GetOK()->Bind(wxEVT_BUTTON, &PA_Calibration_Dlg::on_start, this);
 
@@ -399,13 +392,14 @@ Temp_Calibration_Dlg::Temp_Calibration_Dlg(wxWindow* parent, wxWindowID id, Plat
     v_sizer->Add(settings_sizer, 0, wxTOP | wxRIGHT | wxLEFT | wxEXPAND, FromDIP(10));
     v_sizer->AddSpacer(FromDIP(5));
 
-    auto help_link = new wxHyperlinkCtrl(this, wxID_ANY, _L("Wiki Guide: Temperature Calibration"),
-        "https://www.orcaslicer.com/wiki/temp-calib");
-    help_link->SetForegroundColour(wxColour("#1890FF"));
-    v_sizer->Add(help_link, 0, wxALL, FromDIP(10));
-
     auto dlg_btns = new DialogButtons(this, {"OK"});
-    v_sizer->Add(dlg_btns , 0, wxEXPAND);
+
+    auto bottom_sizer = new wxBoxSizer(wxHORIZONTAL);
+    auto wiki = new HyperLink(this, _L("Wiki Guide"), "https://www.orcaslicer.com/wiki/temp-calib");
+    bottom_sizer->Add(wiki, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, FromDIP(20));
+    bottom_sizer->AddStretchSpacer();
+    bottom_sizer->Add(dlg_btns, 0, wxEXPAND);
+    v_sizer->Add(bottom_sizer, 0, wxEXPAND);
 
     dlg_btns->GetOK()->Bind(wxEVT_BUTTON, &Temp_Calibration_Dlg::on_start, this);
 
@@ -578,13 +572,14 @@ MaxVolumetricSpeed_Test_Dlg::MaxVolumetricSpeed_Test_Dlg(wxWindow* parent, wxWin
     v_sizer->Add(settings_sizer, 0, wxTOP | wxRIGHT | wxLEFT | wxEXPAND, FromDIP(10));
     v_sizer->AddSpacer(FromDIP(5));
 
-    auto help_link = new wxHyperlinkCtrl(this, wxID_ANY, _L("Wiki Guide: Volumetric Speed Calibration"),
-        "https://www.orcaslicer.com/wiki/volumetric-speed-calib");
-    help_link->SetForegroundColour(wxColour("#1890FF"));
-    v_sizer->Add(help_link, 0, wxALL, FromDIP(10));
-
     auto dlg_btns = new DialogButtons(this, {"OK"});
-    v_sizer->Add(dlg_btns , 0, wxEXPAND);
+
+    auto bottom_sizer = new wxBoxSizer(wxHORIZONTAL);
+    auto wiki = new HyperLink(this, _L("Wiki Guide"), "https://www.orcaslicer.com/wiki/volumetric-speed-calib");
+    bottom_sizer->Add(wiki, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, FromDIP(20));
+    bottom_sizer->AddStretchSpacer();
+    bottom_sizer->Add(dlg_btns, 0, wxEXPAND);
+    v_sizer->Add(bottom_sizer, 0, wxEXPAND);
 
     dlg_btns->GetOK()->Bind(wxEVT_BUTTON, &MaxVolumetricSpeed_Test_Dlg::on_start, this);
 
@@ -684,13 +679,14 @@ VFA_Test_Dlg::VFA_Test_Dlg(wxWindow* parent, wxWindowID id, Plater* plater)
     v_sizer->Add(settings_sizer, 0, wxTOP | wxRIGHT | wxLEFT | wxEXPAND, FromDIP(10));
     v_sizer->AddSpacer(FromDIP(5));
 
-    auto help_link = new wxHyperlinkCtrl(this, wxID_ANY, _L("Wiki Guide: VFA"),
-        "https://www.orcaslicer.com/wiki/vfa-calib");
-    help_link->SetForegroundColour(wxColour("#1890FF"));
-    v_sizer->Add(help_link, 0, wxALL, FromDIP(10));
-
     auto dlg_btns = new DialogButtons(this, {"OK"});
-    v_sizer->Add(dlg_btns , 0, wxEXPAND);
+
+    auto bottom_sizer = new wxBoxSizer(wxHORIZONTAL);
+    auto wiki = new HyperLink(this, _L("Wiki Guide"), "https://www.orcaslicer.com/wiki/vfa-calib");
+    bottom_sizer->Add(wiki, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, FromDIP(20));
+    bottom_sizer->AddStretchSpacer();
+    bottom_sizer->Add(dlg_btns, 0, wxEXPAND);
+    v_sizer->Add(bottom_sizer, 0, wxEXPAND);
 
     dlg_btns->GetOK()->Bind(wxEVT_BUTTON, &VFA_Test_Dlg::on_start, this);
 
@@ -791,13 +787,14 @@ Retraction_Test_Dlg::Retraction_Test_Dlg(wxWindow* parent, wxWindowID id, Plater
     v_sizer->Add(settings_sizer, 0, wxTOP | wxRIGHT | wxLEFT | wxEXPAND, FromDIP(10));
     v_sizer->AddSpacer(FromDIP(5));
 
-    auto help_link = new wxHyperlinkCtrl(this, wxID_ANY, _L("Wiki Guide: Retraction Calibration"),
-        "https://www.orcaslicer.com/wiki/retraction-calib");
-    help_link->SetForegroundColour(wxColour("#1890FF"));
-    v_sizer->Add(help_link, 0, wxALL, FromDIP(10));
-
     auto dlg_btns = new DialogButtons(this, {"OK"});
-    v_sizer->Add(dlg_btns , 0, wxEXPAND);
+
+    auto bottom_sizer = new wxBoxSizer(wxHORIZONTAL);
+    auto wiki = new HyperLink(this, _L("Wiki Guide"), "https://www.orcaslicer.com/wiki/retraction-calib");
+    bottom_sizer->Add(wiki, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, FromDIP(20));
+    bottom_sizer->AddStretchSpacer();
+    bottom_sizer->Add(dlg_btns, 0, wxEXPAND);
+    v_sizer->Add(bottom_sizer, 0, wxEXPAND);
 
     dlg_btns->GetOK()->Bind(wxEVT_BUTTON, &Retraction_Test_Dlg::on_start, this);
 
@@ -968,13 +965,14 @@ Input_Shaping_Freq_Test_Dlg::Input_Shaping_Freq_Test_Dlg(wxWindow* parent, wxWin
     v_sizer->Add(settings_sizer, 0, wxTOP | wxRIGHT | wxLEFT | wxEXPAND, FromDIP(10));
     v_sizer->AddSpacer(FromDIP(5));
 
-    auto help_link = new wxHyperlinkCtrl(this, wxID_ANY, _L("Wiki Guide: Input Shaping Calibration"),
-        "https://www.orcaslicer.com/wiki/input-shaping-calib");
-    help_link->SetForegroundColour(wxColour("#1890FF"));
-    v_sizer->Add(help_link, 0, wxALL, FromDIP(10));
-
     auto dlg_btns = new DialogButtons(this, {"OK"});
-    v_sizer->Add(dlg_btns , 0, wxEXPAND);
+
+    auto bottom_sizer = new wxBoxSizer(wxHORIZONTAL);
+    auto wiki = new HyperLink(this, _L("Wiki Guide"), "https://www.orcaslicer.com/wiki/input-shaping-calib");
+    bottom_sizer->Add(wiki, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, FromDIP(20));
+    bottom_sizer->AddStretchSpacer();
+    bottom_sizer->Add(dlg_btns, 0, wxEXPAND);
+    v_sizer->Add(bottom_sizer, 0, wxEXPAND);
 
     dlg_btns->GetOK()->Bind(wxEVT_BUTTON, &Input_Shaping_Freq_Test_Dlg::on_start, this);
 
@@ -1165,13 +1163,14 @@ Input_Shaping_Damp_Test_Dlg::Input_Shaping_Damp_Test_Dlg(wxWindow* parent, wxWin
     v_sizer->Add(settings_sizer, 0, wxTOP | wxRIGHT | wxLEFT | wxEXPAND, FromDIP(10));
     v_sizer->AddSpacer(FromDIP(5));
 
-    auto help_link = new wxHyperlinkCtrl(this, wxID_ANY, _L("Wiki Guide: Input Shaping Calibration"),
-        "https://www.orcaslicer.com/wiki/input-shaping-calib");
-    help_link->SetForegroundColour(wxColour("#1890FF"));
-    v_sizer->Add(help_link, 0, wxALL, FromDIP(10));
-
     auto dlg_btns = new DialogButtons(this, {"OK"});
-    v_sizer->Add(dlg_btns , 0, wxEXPAND);
+
+    auto bottom_sizer = new wxBoxSizer(wxHORIZONTAL);
+    auto wiki = new HyperLink(this, _L("Wiki Guide"), "https://www.orcaslicer.com/wiki/input-shaping-calib");
+    bottom_sizer->Add(wiki, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, FromDIP(20));
+    bottom_sizer->AddStretchSpacer();
+    bottom_sizer->Add(dlg_btns, 0, wxEXPAND);
+    v_sizer->Add(bottom_sizer, 0, wxEXPAND);
 
     dlg_btns->GetOK()->Bind(wxEVT_BUTTON, &Input_Shaping_Damp_Test_Dlg::on_start, this);
 
@@ -1356,13 +1355,14 @@ Cornering_Test_Dlg::Cornering_Test_Dlg(wxWindow* parent, wxWindowID id, Plater* 
     v_sizer->Add(settings_sizer, 0, wxTOP | wxRIGHT | wxLEFT | wxEXPAND, FromDIP(10));
     v_sizer->AddSpacer(FromDIP(5));
 
-    auto help_link = new wxHyperlinkCtrl(this, wxID_ANY, _L("Wiki Guide: Cornering Calibration"),
-        "https://www.orcaslicer.com/wiki/cornering-calib");
-    help_link->SetForegroundColour(wxColour("#1890FF"));
-    v_sizer->Add(help_link, 0, wxALL, FromDIP(10));
-
     auto dlg_btns = new DialogButtons(this, {"OK"});
-    v_sizer->Add(dlg_btns , 0, wxEXPAND);
+
+    auto bottom_sizer = new wxBoxSizer(wxHORIZONTAL);
+    auto wiki = new HyperLink(this, _L("Wiki Guide"), "https://www.orcaslicer.com/wiki/cornering-calib");
+    bottom_sizer->Add(wiki, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, FromDIP(20));
+    bottom_sizer->AddStretchSpacer();
+    bottom_sizer->Add(dlg_btns, 0, wxEXPAND);
+    v_sizer->Add(bottom_sizer, 0, wxEXPAND);
 
     dlg_btns->GetOK()->Bind(wxEVT_BUTTON, &Cornering_Test_Dlg::on_start, this);
 


### PR DESCRIPTION
### FIXES
• 3mf file version check dialog opens bambu releases page instead Orca

### CODE COMPARISON

<img width="112" height="36" alt="Screenshot-20251128125737" src="https://github.com/user-attachments/assets/73718a18-8159-43d5-bb80-0eb90d59a8f6" />

**wxHyperlinkCtrl**
• System decides what colors to use. so blue color is visible even with colors set • No need to use SetCursor()
```
auto wiki_url = "https://github.com/OrcaSlicer/OrcaSlicer/wiki/Built-in-placeholders-variables";
wxHyperlinkCtrl* wiki = new wxHyperlinkCtrl(this, wxID_ANY, _L("Wiki Guide"), wiki_url);
wiki->SetToolTip(wiki_url); // required to showing navigation point to user
wiki->SetFont(Label::Body_14); // not works properly
wiki->SetVisitedColour(wxColour("#009687")); // not works properly
wiki->SetHoverColour(  wxColour("#26A69A")); // not works properly
wiki->SetNormalColour( wxColour("#009687")); // not works properly
```

<img width="132" height="39" alt="Screenshot-20251128125847" src="https://github.com/user-attachments/assets/f6818dc0-5078-498a-bf09-1fd36e81ebe5" />

**wxStaticText**
• Works reliably on colors and fonts
• All event has to defined manually
```
wxStaticText* wiki = new wxStaticText(this, wxID_ANY, _L("Wiki Guide"));
auto wiki_url = "https://github.com/OrcaSlicer/OrcaSlicer/wiki/Built-in-placeholders-variables";
wiki->SetToolTip(wiki_url); // required to showing navigation point to user
wiki->SetForegroundColour(wxColour("#009687"));
wiki->SetCursor(wxCURSOR_HAND);
wxFont font = Label::Body_14;
font.SetUnderlined(true);
wiki->SetFont(font);
wiki->Bind(wxEVT_LEFT_DOWN   ,[this, wiki_url](wxMouseEvent e) {wxLaunchDefaultBrowser(wiki_url);});
wiki->Bind(wxEVT_ENTER_WINDOW,[this, wiki    ](wxMouseEvent e) {SetForegroundColour(wxColour("#26A69A"));});
wiki->Bind(wxEVT_LEAVE_WINDOW,[this, wiki    ](wxMouseEvent e) {SetForegroundColour(wxColour("#009687"));});
```

<img width="132" height="39" alt="Screenshot-20251128125847" src="https://github.com/user-attachments/assets/f6818dc0-5078-498a-bf09-1fd36e81ebe5" />

**HyperLink**
• Fully automated and single line solution
• Colors can be controllable from one place
• Works reliably on colors and fonts
• Reduces duplicate code
```
HyperLink* wiki = new HyperLink(this, _L("Wiki Guide"), "https://github.com/OrcaSlicer/OrcaSlicer/wiki/Built-in-placeholders-variables");
wiki->SetFont(Label::Body_14) // OPTIONAL default is Label::Body_14;
```


### CHANGES
• Unifies all hyperlinks with same style and makes them controllable from one place • Replaces all wxHyperlink with simple custom class. Problem with wxHyperlink it mostly rendered as blue even color set • Reduces duplicate code
• Adds wiki links for calibration dialogs
• Probably will add "Wiki Guide" to more dialogs overtime

<img width="349" height="238" alt="Screenshot-20251127212007" src="https://github.com/user-attachments/assets/69da2732-ea35-44de-8ebc-97a01f86328f" />

<img width="355" height="459" alt="Screenshot-20251127212021" src="https://github.com/user-attachments/assets/c0df40f8-c15d-47fa-b31a-cf8d8b337472" />

<img width="442" height="382" alt="Screenshot-20251127212046" src="https://github.com/user-attachments/assets/5d94242b-6364-4b0a-8b2f-a1f482199bd1" />

<img width="225" height="241" alt="Screenshot-20250824171339" src="https://github.com/user-attachments/assets/39ca6af3-6f8a-42ee-bf1d-c13d0f54bb63" />

<img width="442" height="639" alt="Screenshot-20251127212403" src="https://github.com/user-attachments/assets/c1c580f8-3e1b-42f0-aa8e-bac41c2ff76b" />

<img width="476" height="286" alt="Screenshot-20251127212515" src="https://github.com/user-attachments/assets/28b130ce-c7c0-4ada-9842-ff7154c00c21" />

<img width="1460" height="245" alt="Screenshot-20251127212541" src="https://github.com/user-attachments/assets/3fca2649-9cd3-4aea-9153-b2f508fdfefe" />

<img width="401" height="291" alt="Screenshot-20251127213243" src="https://github.com/user-attachments/assets/82b4ec1f-6074-4018-9efa-a1b6b819ae28" />

<!--
# THIS FORK IS UNSTABLE AND UNOFFICIAL DO NOT REPORT BUGS FOUND HERE TO THE OFFICIAL VERSION
-->

# Pull Request

## Important Notice

**This is an unofficial fork of OrcaSlicer.** Please do **not** report issues from this fork to the official OrcaSlicer repository.

## Summary

<!--
- What does this change do?
- Why is it needed?
-->

## Testing

<!--
# To mark checkboxes place an `X` in them inside the `[ ]` like `[X]`.
-->

- [ ] Not tested (explain why below)
- [ ] Manual (describe steps below)
- [ ] Automated (list tests run below)

## Testing extra info

<!--
Add the extra context from above here
-->

## Screenshots / Videos (optional)

<!--
- Before: <img>
- After: <img>
- Video: <vid>
-->

## Additional Context (optional)

<!--
Add any helpful context for reviewers:
- Commands/logs: e.g., build/run commands, failing test output
- Platform: OS/CPU/GPU, driver versions
- Hardware: printer model/firmware, accessories
- Other notes: configs, presets, links to related issues
- Related issues/links, docs, migration notes, presets impacted, etc.
-->

## Contributor Checklist

<!--
# To mark checkboxes place an `X` in them inside the `[ ]` like `[X]`.
-->

- [ ] I understand this is an unofficial fork and will only open upstream issues when they are reproducible on the official OrcaSlicer
- [ ] I verified the change builds locally or in CI when applicable
- [ ] I added or updated tests where it makes sense
- [ ] I updated docs, presets, or localization if the change affects them
