### PR TITLE
Potential fix for code scanning alert no. 61: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check_profiles.yml
+++ b/.github/workflows/check_profiles.yml
@@ -1,4 +1,6 @@
 name: Check profiles
+permissions:
+  contents: read
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/NanashiTheNameless/OrcaSlicer/security/code-scanning/61](https://github.com/NanashiTheNameless/OrcaSlicer/security/code-scanning/61)

In general, this issue is fixed by explicitly declaring a `permissions` block either at the top (workflow) level or under each job, granting only the specific scopes needed (principle of least privilege). Since the `check_translation` job only needs to read the repository contents (for `actions/checkout` and `python`/validator scripts) and does not update GitHub resources, the minimal safe permission is `contents: read`.

The best fix with no functional change is to add a root-level `permissions` block under the `name:` (and before `on:`) or just below `on:`. A root-level block applies to all jobs that don’t override it, so we only need to add it once. No imports or other code changes are required. Concretely, in `.github/workflows/check_profiles.yml`, insert:

```yaml
permissions:
  contents: read
```

near the top of the file, ensuring indentation matches YAML structure (no indentation at the root level). This constrains `GITHUB_TOKEN` to read-only repository contents for this workflow while preserving existing behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
