### PR TITLE
Increase maximum plate count from 64 to 96

### DIFF
--- a/src/slic3r/GUI/PartPlate.hpp
+++ b/src/slic3r/GUI/PartPlate.hpp
@@ -33,7 +33,7 @@ typedef class GLUquadric GLUquadricObject;
 #define PLATE_CURRENT_IDX   -1
 #define PLATE_ALL_IDX       -2
 
-#define MAX_PLATE_COUNT     64
+#define MAX_PLATE_COUNT     96
 
 inline int compute_colum_count(int count)
 {


### PR DESCRIPTION
<!--
# THIS FORK IS UNSTABLE AND UNOFFICIAL DO NOT REPORT BUGS FOUND HERE TO THE OFFICIAL VERSION
-->

# Pull Request

## Important Notice

**This is an unofficial fork of OrcaSlicer.** Please do **not** report issues from this fork to the official OrcaSlicer repository.

## Summary

This pull request increases the maximum allowed number of plates in the application. The change is straightforward and only updates the `MAX_PLATE_COUNT` constant.

- Increased the value of `MAX_PLATE_COUNT` from 64 to 96 in `PartPlate.hpp` to allow for more plates.

## Testing

<!--
# To mark checkboxes place an `X` in them inside the `[ ]` like `[X]`.
-->

- [X] Not tested (explain why below)
- [ ] Manual (describe steps below)
- [ ] Automated (list tests run below)

## Testing extra info

Testing with PR Build

## Screenshots / Videos (optional)

N/A

## Additional Context (optional)

N/A

## Contributor Checklist

<!--
# To mark checkboxes place an `X` in them inside the `[ ]` like `[X]`.
-->

- [X] I understand this is an unofficial fork and will only open upstream issues when they are reproducible on the official OrcaSlicer
- [X] I verified the change builds locally or in CI when applicable
- [X] I added or updated tests where it makes sense
- [X] I updated docs, presets, or localization if the change affects them