### PR TITLE
Potential fix for code scanning alert no. 62: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/winget_updater.yml
+++ b/.github/workflows/winget_updater.yml
@@ -5,6 +5,9 @@ on:
 jobs:
   publish:
     runs-on: windows-latest
+    permissions:
+      contents: read
+      packages: read
     steps:
       - uses: vedantmgoyal9/winget-releaser@main
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/NanashiTheNameless/OrcaSlicer/security/code-scanning/62](https://github.com/NanashiTheNameless/OrcaSlicer/security/code-scanning/62)

In general, the fix is to define an explicit `permissions:` block in the workflow, either at the top level (affecting all jobs) or within the specific job. This block should grant only the minimal GITHUB_TOKEN permissions required by the workflow. If uncertain, start with a very restrictive configuration such as `contents: read` and widen only if the workflow fails due to insufficient permissions.

For this specific workflow, the simplest non-breaking fix is to add a job-level `permissions:` block under `jobs.publish` that grants read access to repository contents and packages, which should be sufficient for reading release/tag metadata that the `winget-releaser` action uses. We will therefore insert:

```yaml
permissions:
  contents: read
  packages: read
```

under `jobs.publish`, keeping the rest of the job intact. This change is localized to `.github/workflows/winget_updater.yml` and does not alter any functional behavior beyond tightening the GITHUB_TOKEN scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
