### PR TITLE
Fix stable sort and comparator for staggered perimeters

### DIFF
--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -2493,9 +2493,9 @@ void PerimeterGenerator::process_arachne()
         }
 
         if (this->config->staggered_perimeters) { // If staggered layers are on, all odd perimeters will be staggered and should be printed after the non staggered perimeters
-            std::sort(ordered_extrusions.begin(), ordered_extrusions.end(),
+            std::stable_sort(ordered_extrusions.begin(), ordered_extrusions.end(),
                 [](PerimeterGeneratorArachneExtrusion extrusion_1, PerimeterGeneratorArachneExtrusion extrusion_2) -> bool {
-                return extrusion_1.extrusion->inset_idx % 2 <= extrusion_2.extrusion->inset_idx % 2;
+                return extrusion_1.extrusion->inset_idx % 2 < extrusion_2.extrusion->inset_idx % 2;
                 });
         }
 


### PR DESCRIPTION
<!--
# THIS FORK IS UNSTABLE AND UNOFFICIAL DO NOT REPORT BUGS FOUND HERE TO THE OFFICIAL VERSION
-->

# Pull Request

## Important Notice

**This is an unofficial fork of OrcaSlicer.** Please do **not** report issues from this fork to the official OrcaSlicer repository.

## Summary

This should close https://github.com/NanashiTheNameless/OrcaSlicer/issues/302

## Contributor Checklist

<!--
# To mark checkboxes place an `X` in them inside the `[ ]` like `[X]`.
-->

- [X] I understand this is an unofficial fork and will only open upstream issues when they are reproducible on the official OrcaSlicer
- [X] I verified the change builds locally or in CI when applicable
- [X] I added or updated tests where it makes sense
- [X] I updated docs, presets, or localization if the change affects them
